### PR TITLE
feat: Implement spinner component in design system #24

### DIFF
--- a/apps/web/components/DesignSystem.tsx
+++ b/apps/web/components/DesignSystem.tsx
@@ -7,6 +7,7 @@ import {
 	Flex,
 	Heading,
 	Input,
+	Spinner,
 	Text,
 	Textarea,
 } from '@jung/design-system';
@@ -64,6 +65,7 @@ const DesignSystem = () => {
 				<Text text='이건 p태그' />
 			</Flex>
 			<Divider />
+			<Spinner />
 			<Heading as='h3' text='CheckBox 컴포넌트' />
 			<CheckBoxTest />
 		</>

--- a/packages/design-system/components/Button/Button.tsx
+++ b/packages/design-system/components/Button/Button.tsx
@@ -1,41 +1,42 @@
-import { button } from "./Button.css";
+import { button } from './Button.css';
 
 import {
 	type ButtonHTMLAttributes,
 	type PropsWithChildren,
 	type ReactNode,
 	forwardRef,
-} from "react";
+} from 'react';
 
-import { Box, type BoxProps } from "..";
+import { Box, type BoxProps } from '..';
 
 interface Props
 	extends PropsWithChildren<
-		Omit<ButtonHTMLAttributes<HTMLButtonElement>, "prefix">
+		Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'prefix'>
 	> {
-	variant?: "primary" | "secondary" | "outline" | "ghost";
-	size?: "sm" | "md" | "lg";
+	variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
+	size?: 'sm' | 'md' | 'lg';
 	rounded?: boolean;
 	prefix?: ReactNode;
 	suffix?: ReactNode;
+	loading?: boolean;
 }
 
-type ButtonProps = BoxProps<"button", Props>;
+type ButtonProps = BoxProps<'button', Props>;
 export type ButtonComponent = (props: ButtonProps) => ReactNode;
 
 export const Button: ButtonComponent = forwardRef(
 	(
-		{ variant, size, rounded, prefix, suffix, children, ...restProps },
+		{ variant, size, rounded, prefix, suffix, loading, children, ...restProps },
 		ref?,
 	) => {
 		const buttonClass = button({ variant, size, rounded });
 
 		return (
 			<Box
-				as="button"
-				display="flex"
-				alignItems="center"
-				columnGap="1"
+				as='button'
+				display='flex'
+				alignItems='center'
+				columnGap='1'
 				className={buttonClass}
 				ref={ref}
 				{...restProps}

--- a/packages/design-system/components/Button/button.css.ts
+++ b/packages/design-system/components/Button/button.css.ts
@@ -72,6 +72,7 @@ export const button = recipe({
 				borderRadius: '2xl',
 			}),
 		},
+		loading: {},
 	},
 	defaultVariants: {
 		variant: 'primary',

--- a/packages/design-system/components/Spinner/Spinner.css.ts
+++ b/packages/design-system/components/Spinner/Spinner.css.ts
@@ -1,0 +1,17 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+const rotateAnimation = keyframes({
+	'0%': {
+		strokeDashoffset: 44,
+	},
+	'100%': {
+		strokeDashoffset: 220,
+	},
+});
+
+export const circle = style({
+	animation: `${rotateAnimation} 1s linear 1ms infinite`,
+	strokeDasharray: '100,76',
+	strokeDashoffset: 44,
+	strokeLinecap: 'round',
+});

--- a/packages/design-system/components/Spinner/Spinner.tsx
+++ b/packages/design-system/components/Spinner/Spinner.tsx
@@ -1,0 +1,41 @@
+import * as styles from './Spinner.css';
+
+import { type HTMLAttributes, forwardRef } from 'react';
+import { Box, type BoxProps } from '..';
+import { palette } from '../../tokens';
+
+interface Props extends HTMLAttributes<HTMLOrSVGElement> {
+	size?: number;
+	sw?: number;
+	// svgProps?: SVGProps<SVGSVGElement>;
+}
+
+type SpinnerProps = BoxProps<'svg', Props>;
+type SpinnerComponent = (props: SpinnerProps) => React.ReactNode;
+
+export const Spinner: SpinnerComponent = forwardRef(
+	({ size = 6, sw = 1, color, ...restProps }, ref) => {
+		return (
+			<Box
+				as='svg'
+				width={size}
+				height={size}
+				x={size}
+				y={size}
+				viewBox={`0 0 ${size} ${size}`}
+				ref={ref}
+				{...restProps}
+			>
+				<circle
+					className={styles.circle}
+					cx={size / 2}
+					cy={size / 2}
+					r={(size - sw) / 2}
+					fill='none'
+					stroke={color || palette.primary200}
+					stroke-width={sw}
+				/>
+			</Box>
+		);
+	},
+);

--- a/packages/design-system/components/index.ts
+++ b/packages/design-system/components/index.ts
@@ -1,3 +1,4 @@
+export { Spinner } from './Spinner/Spinner';
 export { Divider } from './Divider/Divider';
 export { Text } from './Typography/Text';
 export { Heading } from './Typography/Heading';


### PR DESCRIPTION
## Motivation 🤔

- The goal is to add a Spinner component without a library to the design system to clearly separate UI elements.

<br>

## Key Changes 🔑

- Implement spinner component

<br>

## To Reviews 🙏🏻

- Check if it is a flexible component that can accept colour and size props.

@dgd03146 
