### PR TITLE
feat: Implement Spot CRUD operations and image handling

### DIFF
--- a/apps/admin/src/features/gallery/ui/NewPhoto.tsx
+++ b/apps/admin/src/features/gallery/ui/NewPhoto.tsx
@@ -331,7 +331,9 @@ export const NewPhoto = () => {
 					<button
 						type='submit'
 						className={styles.submitButton}
-						disabled={createPhotoMutation.isPending}
+						disabled={
+							createPhotoMutation.isPending || updatePhotoMutation.isPending
+						}
 					>
 						{isEditMode ? 'Update Photo' : 'Create Photo'}
 					</button>

--- a/apps/admin/src/features/spots/api/useCreateSpot.ts
+++ b/apps/admin/src/features/spots/api/useCreateSpot.ts
@@ -1,0 +1,50 @@
+import { spotKeys } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import { useToast } from '@jung/design-system/components';
+import type { Spot } from '@jung/shared/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { createSpot } from '../services/createSpot';
+
+type CreateSpotInput = Omit<
+	Spot,
+	'id' | 'created_at' | 'updated_at' | 'likes' | 'liked_by'
+>;
+
+export function useCreateSpot() {
+	const queryClient = useQueryClient();
+	const showToast = useToast();
+	const navigate = useNavigate();
+
+	return useMutation({
+		mutationFn: (data: CreateSpotInput) => createSpot(data),
+
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: spotKeys.lists(),
+			});
+			showToast(`Spot "${variables.title}" created successfully!`, 'success');
+			navigate({ to: '/spots' });
+		},
+
+		onError: (error: unknown) => {
+			if (error instanceof ApiError) {
+				switch (error.code) {
+					case 'FOREIGN_KEY_VIOLATION':
+						showToast('Invalid category', 'error');
+						break;
+					case 'VALIDATION_ERROR':
+						showToast('Invalid input', 'error');
+						break;
+					case 'STORAGE_ERROR':
+						showToast('Failed to upload image', 'error');
+						break;
+					default:
+						showToast(`Create failed: ${error.message}`, 'error');
+				}
+			} else {
+				showToast('An unknown error occurred', 'error');
+			}
+		},
+	});
+}

--- a/apps/admin/src/features/spots/api/useCreateSpot.ts
+++ b/apps/admin/src/features/spots/api/useCreateSpot.ts
@@ -1,15 +1,9 @@
 import { spotKeys } from '@/fsd/shared';
 import { ApiError } from '@/fsd/shared/lib/errors/apiError';
 import { useToast } from '@jung/design-system/components';
-import type { Spot } from '@jung/shared/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { createSpot } from '../services/createSpot';
-
-type CreateSpotInput = Omit<
-	Spot,
-	'id' | 'created_at' | 'updated_at' | 'likes' | 'liked_by'
->;
+import { type CreateSpotInput, createSpot } from '../services/createSpot';
 
 export function useCreateSpot() {
 	const queryClient = useQueryClient();
@@ -28,6 +22,7 @@ export function useCreateSpot() {
 		},
 
 		onError: (error: unknown) => {
+			console.log(error, 'error');
 			if (error instanceof ApiError) {
 				switch (error.code) {
 					case 'FOREIGN_KEY_VIOLATION':

--- a/apps/admin/src/features/spots/api/useDeleteSpot.ts
+++ b/apps/admin/src/features/spots/api/useDeleteSpot.ts
@@ -1,62 +1,43 @@
 import { spotKeys } from '@/fsd/shared';
-import type { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
 import { useToast } from '@jung/design-system/components';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-
-// Mock delete function
-const mockDeleteSpotById = async (id: string): Promise<void> => {
-	// Simulate API delay
-	await new Promise((resolve) => setTimeout(resolve, 500));
-
-	// Simulate random error (10% chance)
-	if (Math.random() < 0.1) {
-		throw {
-			code: 'NOT_FOUND',
-			message: '해당 장소를 찾을 수 없습니다.',
-		} as ApiError;
-	}
-
-	// Simulate permission error (5% chance)
-	if (Math.random() < 0.05) {
-		throw {
-			code: 'PERMISSION_DENIED',
-			message: '이 장소를 삭제할 권한이 없습니다.',
-		} as ApiError;
-	}
-
-	console.log('Mock: Spot deleted', id);
-	return;
-};
+import { deleteSpot } from '../services/deleteSpot';
 
 export const useDeleteSpot = () => {
 	const queryClient = useQueryClient();
 	const showToast = useToast();
 
 	return useMutation({
-		mutationFn: (id: string) => mockDeleteSpotById(id),
-		onSuccess: async (_, deletedId) => {
-			await queryClient.invalidateQueries({ queryKey: spotKeys.lists() });
-			queryClient.removeQueries({ queryKey: spotKeys.detail(deletedId) });
+		mutationFn: deleteSpot,
 
-			showToast('장소가 성공적으로 삭제되었습니다.');
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: spotKeys.lists(),
+			});
+			showToast('스팟이 성공적으로 삭제되었습니다.', 'success');
 		},
-		onError: (error: ApiError) => {
-			switch (error.code) {
-				case 'NOT_FOUND':
-					showToast('장소 삭제 실패: 해당 장소를 찾을 수 없습니다.');
-					break;
-				case 'PERMISSION_DENIED':
-					showToast('장소 삭제 실패: 권한이 없습니다.');
-					break;
-				case 'UNKNOWN_ERROR':
-					showToast(
-						'예기치 않은 오류가 발생했습니다. 나중에 다시 시도해주세요.',
-					);
-					break;
-				default:
-					showToast(`장소 삭제 실패: ${error.message}`);
+
+		onError: (error: unknown) => {
+			console.error('Failed to delete spot:', error);
+
+			if (error instanceof ApiError) {
+				switch (error.code) {
+					case 'NOT_FOUND':
+						showToast('스팟을 찾을 수 없습니다.', 'error');
+						break;
+					case 'FOREIGN_KEY_VIOLATION':
+						showToast(
+							'이 스팟과 연관된 데이터가 있어 삭제할 수 없습니다.',
+							'error',
+						);
+						break;
+					default:
+						showToast(`삭제 실패: ${error.message}`, 'error');
+				}
+			} else {
+				showToast('알 수 없는 오류가 발생했습니다.', 'error');
 			}
-			console.error('Spot deletion error:', error);
 		},
 	});
 };

--- a/apps/admin/src/features/spots/api/useGetSpotById.ts
+++ b/apps/admin/src/features/spots/api/useGetSpotById.ts
@@ -1,0 +1,11 @@
+import { spotKeys } from '@/fsd/shared';
+import { useQuery } from '@tanstack/react-query';
+import { getSpotById } from '../services/getSpotById';
+
+export function useGetSpotById(id: string) {
+	return useQuery({
+		queryKey: spotKeys.detail(id),
+		queryFn: () => getSpotById(id),
+		enabled: !!id,
+	});
+}

--- a/apps/admin/src/features/spots/api/useGetSpotCategories.ts
+++ b/apps/admin/src/features/spots/api/useGetSpotCategories.ts
@@ -1,0 +1,11 @@
+import { categoryKeys } from '@/fsd/shared';
+import { useQuery } from '@tanstack/react-query';
+import { fetchSpotCategories } from '../services/getCategories';
+
+export function useGetSpotCategories() {
+	return useQuery({
+		queryKey: categoryKeys.all('spots'),
+		queryFn: fetchSpotCategories,
+		staleTime: 1000 * 60 * 60,
+	});
+}

--- a/apps/admin/src/features/spots/api/useGetSpots.ts
+++ b/apps/admin/src/features/spots/api/useGetSpots.ts
@@ -1,0 +1,22 @@
+import { spotKeys } from '@/fsd/shared';
+import type { Spot } from '@jung/shared/types';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { fetchSpots } from '../services/getSpots';
+
+interface SpotFilters {
+	page: number;
+	pageSize: number;
+	sortField?: keyof Spot;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+}
+
+export function useGetSpots(filters: SpotFilters) {
+	return useQuery({
+		queryKey: spotKeys.list(filters),
+		queryFn: () => fetchSpots(filters),
+		placeholderData: keepPreviousData,
+		staleTime: 1000 * 60 * 60 * 24, // 24시간
+		gcTime: 1000 * 60 * 60 * 24 * 7, // 7일
+	});
+}

--- a/apps/admin/src/features/spots/api/useUpdateSpot.ts
+++ b/apps/admin/src/features/spots/api/useUpdateSpot.ts
@@ -1,0 +1,53 @@
+import { spotKeys } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import { useToast } from '@jung/design-system/components';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { updateSpot } from '../services/updateSpot';
+import type { UpdateSpotInput } from '../services/updateSpot';
+
+export const useUpdateSpot = () => {
+	const queryClient = useQueryClient();
+	const showToast = useToast();
+	const navigate = useNavigate();
+
+	return useMutation({
+		mutationFn: (input: UpdateSpotInput) => updateSpot(input),
+
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: spotKeys.detail(variables.id),
+			});
+			queryClient.invalidateQueries({
+				queryKey: spotKeys.lists(),
+			});
+			showToast(`스팟 "${variables.title}"이(가) 수정되었습니다.`, 'success');
+			navigate({ to: '/spots' });
+		},
+
+		onError: (error: unknown) => {
+			console.error('Failed to update spot:', error);
+
+			if (error instanceof ApiError) {
+				switch (error.code) {
+					case 'FOREIGN_KEY_VIOLATION':
+						showToast('유효하지 않은 카테고리입니다.', 'error');
+						break;
+					case 'NO_DATA':
+						showToast('스팟 정보 수정에 실패했습니다.', 'error');
+						break;
+					case 'VALIDATION_ERROR':
+						showToast('입력값이 유효하지 않습니다.', 'error');
+						break;
+					case 'NOT_FOUND':
+						showToast('스팟을 찾을 수 없습니다.', 'error');
+						break;
+					default:
+						showToast(`수정 실패: ${error.message}`, 'error');
+				}
+			} else {
+				showToast('알 수 없는 오류가 발생했습니다.', 'error');
+			}
+		},
+	});
+};

--- a/apps/admin/src/features/spots/lib/uploadImage.ts
+++ b/apps/admin/src/features/spots/lib/uploadImage.ts
@@ -2,13 +2,11 @@ import { generateShortId } from '@/fsd/features/blog/lib';
 import { supabase } from '@/fsd/shared';
 import { ApiError } from '@/fsd/shared/lib/errors/apiError';
 
-// FIXME: 공통 함수로 빼기
-
-const GALLERY_BUCKET = 'gallery_images';
+const SPOTS_BUCKET = 'spots_images';
 
 export const getPublicUrl = (filePath: string): string => {
 	const { data: publicUrlData } = supabase.storage
-		.from(GALLERY_BUCKET)
+		.from(SPOTS_BUCKET)
 		.getPublicUrl(filePath);
 
 	if (!publicUrlData || !publicUrlData.publicUrl) {
@@ -41,7 +39,7 @@ const getImageDimensions = (file: File): Promise<ImageMetadata> => {
 	});
 };
 
-export const uploadGalleryImage = async (
+export const uploadSpotImage = async (
 	file: File,
 ): Promise<{
 	url: string;
@@ -49,6 +47,14 @@ export const uploadGalleryImage = async (
 	height: number;
 }> => {
 	try {
+		if (!file.type.startsWith('image/')) {
+			throw new ApiError('Invalid file type', 'VALIDATION_ERROR');
+		}
+
+		// if (file.size > 5 * 1024 * 1024) {
+		// 	throw new ApiError('File size too large (max 5MB)', 'VALIDATION_ERROR');
+		// }
+
 		const { width, height } = await getImageDimensions(file);
 
 		const fileExt = file.name.split('.').pop();
@@ -57,7 +63,7 @@ export const uploadGalleryImage = async (
 		const filePath = `uploads/${fileName}`;
 
 		const { error: uploadError } = await supabase.storage
-			.from(GALLERY_BUCKET)
+			.from(SPOTS_BUCKET)
 			.upload(filePath, file, { upsert: false });
 
 		if (uploadError) {

--- a/apps/admin/src/features/spots/model/useSpotTable.ts
+++ b/apps/admin/src/features/spots/model/useSpotTable.ts
@@ -47,32 +47,32 @@ export const useSpotTable = () => {
 	const columns = useMemo(
 		() => [
 			{
-				header: '썸네일',
+				header: 'Thumbnails',
 				accessorKey: 'photos',
 				size: 100,
 			},
 			{
-				header: '제목',
+				header: 'Title',
 				accessorKey: 'title',
 				size: 200,
 			},
 			{
-				header: '카테고리',
+				header: 'Category',
 				accessorKey: 'category',
 				size: 150,
 			},
 			{
-				header: '주소',
+				header: 'Address',
 				accessorKey: 'address',
 				size: 300,
 			},
 			{
-				header: '좋아요',
+				header: 'Likes',
 				accessorKey: 'likes',
 				size: 100,
 			},
 			{
-				header: '생성일',
+				header: 'Created At',
 				accessorKey: 'created_at',
 				size: 150,
 			},

--- a/apps/admin/src/features/spots/model/useSpotTable.ts
+++ b/apps/admin/src/features/spots/model/useSpotTable.ts
@@ -1,7 +1,8 @@
-import type { Spot, SpotCategory } from '@jung/shared/types';
+import { spotKeys } from '@/fsd/shared';
+import type { Spot } from '@jung/shared/types';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import {
-	type ColumnDef,
 	type PaginationState,
 	type SortingState,
 	type Updater,
@@ -11,164 +12,24 @@ import {
 	getSortedRowModel,
 	useReactTable,
 } from '@tanstack/react-table';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useGetSpots } from '../api/useGetSpots';
+import { fetchSpots } from '../services/getSpots';
 
 export interface SpotFilters {
 	page: number;
 	pageSize: number;
-	sortField?: string;
+	sortField?: keyof Spot;
 	sortOrder?: 'asc' | 'desc';
 	filter?: string;
 }
 
-export const CATEGORY_LABELS: Record<SpotCategory, string> = {
-	nature: '자연/풍경',
-	landmark: '랜드마크',
-	historic: '역사/문화유산',
-	culture: '문화시설',
-	night: '야경 명소',
-	street: '거리/골목',
-	park: '공원',
-	local: '로컬/전통',
-};
-
 const PAGE_SIZE = 10;
-
-const MOCK_SPOTS: Spot[] = [
-	{
-		id: '123e4567-e89b-12d3-a456-426614174000',
-		title: '남산서울타워',
-		description:
-			'서울의 상징적인 랜드마크이자 최고의 전망대. 아름다운 야경과 레스토랑, 각종 문화시설을 즐길 수 있는 복합문화공간',
-		address: '서울특별시 용산구 남산공원길 105',
-		photos: [
-			{
-				id: 'photo1',
-				url: 'https://picsum.photos/800/600?random=1',
-			},
-			{
-				id: 'photo2',
-				url: 'https://picsum.photos/800/600?random=2',
-			},
-		],
-		rating: 4.5,
-		coordinates: {
-			lat: 37.551168,
-			lng: 126.988228,
-		},
-		category: 'landmark',
-		created_at: '2024-03-20T09:00:00Z',
-		updated_at: '2024-03-20T09:00:00Z',
-		tags: ['전망대', '데이트', '야경', '서울'],
-		tips: ['석양 무렵 방문 추천', '주말은 혼잡', '케이블카 이용시 줄 참고'],
-		likes: 1234,
-		liked_by: [],
-	},
-	{
-		id: '223e4567-e89b-12d3-a456-426614174001',
-		title: '경복궁',
-		description:
-			'조선왕조의 법궁으로, 조선시대 대표적인 건축물. 수려한 전통 건축미와 역사적 가치를 지닌 문화유산',
-		address: '서울특별시 종로구 사직로 161',
-		photos: [
-			{
-				id: 'photo3',
-				url: 'https://picsum.photos/800/600?random=3',
-			},
-		],
-		rating: 4.8,
-		coordinates: {
-			lat: 37.579617,
-			lng: 126.977041,
-		},
-		category: 'historic',
-		created_at: '2024-03-19T09:00:00Z',
-		updated_at: '2024-03-19T09:00:00Z',
-		tags: ['고궁', '한옥', '역사', '문화유산'],
-		tips: ['아침 일찍 방문 추천', '한복 대여 가능', '야간개장 확인'],
-		likes: 2345,
-		liked_by: [],
-	},
-	{
-		id: '323e4567-e89b-12d3-a456-426614174002',
-		title: '한강공원',
-		description:
-			'도심 속 휴식처이자 레저 공간. 자전거 대여, 피크닉, 수상 스포츠 등 다양한 활동이 가능한 복합 공원',
-		address: '서울특별시 영등포구 여의동로 330',
-		photos: [
-			{
-				id: 'photo4',
-				url: 'https://picsum.photos/800/600?random=4',
-			},
-		],
-		rating: 4.3,
-		coordinates: {
-			lat: 37.526389,
-			lng: 126.933611,
-		},
-		category: 'park',
-		created_at: '2024-03-18T09:00:00Z',
-		updated_at: '2024-03-18T09:00:00Z',
-		tags: ['공원', '피크닉', '자전거', '한강'],
-		tips: ['저녁에 치맥 추천', '돗자리 필수', '자전거 대여소 위치 확인'],
-		likes: 1876,
-		liked_by: [],
-	},
-	{
-		id: '423e4567-e89b-12d3-a456-426614174003',
-		title: '북촌한옥마을',
-		description:
-			'전통 한옥이 밀집된 서울의 대표적인 역사문화 마을. 전통 공방과 박물관, 카페 등이 어우러진 문화 공간',
-		address: '서울특별시 종로구 계동길 37',
-		photos: [
-			{
-				id: 'photo5',
-				url: 'https://picsum.photos/800/600?random=5',
-			},
-		],
-		rating: 4.6,
-		coordinates: {
-			lat: 37.582778,
-			lng: 126.983889,
-		},
-		category: 'historic',
-		created_at: '2024-03-17T09:00:00Z',
-		updated_at: '2024-03-17T09:00:00Z',
-		tags: ['한옥', '전통', '문화', '카페'],
-		tips: ['평일 방문 추천', '한복 체험 가능', '골목길 지도 필수'],
-		likes: 3421,
-		liked_by: [],
-	},
-	{
-		id: '523e4567-e89b-12d3-a456-426614174004',
-		title: '동대문디자인플라자',
-		description:
-			'현대적 건축미가 돋보이는 복합 문화 공간. 전시, 쇼핑, 공연 등 다양한 문화 콘텐츠를 즐길 수 있는 랜드마크',
-		address: '서울특별시 중구 을지로 281',
-		photos: [
-			{
-				id: 'photo6',
-				url: 'https://picsum.photos/800/600?random=6',
-			},
-		],
-		rating: 4.4,
-		coordinates: {
-			lat: 37.566667,
-			lng: 127.009722,
-		},
-		category: 'culture',
-		created_at: '2024-03-16T09:00:00Z',
-		updated_at: '2024-03-16T09:00:00Z',
-		tags: ['디자인', '건축', '전시', '쇼핑'],
-		tips: ['야간 촬영 추천', '주변 먹자골목 방문', '전시 일정 체크'],
-		likes: 1543,
-		liked_by: [],
-	},
-];
 
 export const useSpotTable = () => {
 	const navigate = useNavigate();
 	const searchParams = useSearch({ from: '/spots/' }) as SpotFilters;
+	const queryClient = useQueryClient();
 
 	const filters: SpotFilters = useMemo(
 		() => ({
@@ -181,7 +42,9 @@ export const useSpotTable = () => {
 		[searchParams],
 	);
 
-	const columns = useMemo<ColumnDef<Spot>[]>(
+	const { data, isLoading, error, refetch } = useGetSpots(filters);
+
+	const columns = useMemo(
 		() => [
 			{
 				header: '썸네일',
@@ -204,24 +67,9 @@ export const useSpotTable = () => {
 				size: 300,
 			},
 			{
-				header: '위치',
-				accessorKey: 'coordinates',
-				size: 200,
-			},
-			{
-				header: '평점',
-				accessorKey: 'rating',
-				size: 100,
-			},
-			{
 				header: '좋아요',
 				accessorKey: 'likes',
 				size: 100,
-			},
-			{
-				header: '팁',
-				accessorKey: 'tips',
-				size: 250,
 			},
 			{
 				header: '생성일',
@@ -232,6 +80,17 @@ export const useSpotTable = () => {
 		[],
 	);
 
+	// Prefetch next page
+	useEffect(() => {
+		if (data?.hasMore) {
+			const nextPage = filters.page + 1;
+			queryClient.prefetchQuery({
+				queryKey: spotKeys.list({ ...filters, page: nextPage }),
+				queryFn: () => fetchSpots({ ...filters, page: nextPage }),
+			});
+		}
+	}, [data?.hasMore, filters, queryClient]);
+
 	const updateSearchParams = useCallback(
 		(newParams: Partial<SpotFilters>) => {
 			navigate({ search: (prev) => ({ ...prev, ...newParams }) });
@@ -241,7 +100,7 @@ export const useSpotTable = () => {
 
 	const table = useReactTable({
 		columns,
-		data: MOCK_SPOTS,
+		data: data?.spots ?? [],
 		state: {
 			sorting: filters.sortField
 				? [{ id: filters.sortField, desc: filters.sortOrder === 'desc' }]
@@ -275,7 +134,7 @@ export const useSpotTable = () => {
 					: updater;
 			const sort = newSorting[0];
 			updateSearchParams({
-				sortField: sort?.id,
+				sortField: sort?.id as keyof Spot,
 				sortOrder: sort?.desc ? 'desc' : 'asc',
 			});
 		},
@@ -289,13 +148,13 @@ export const useSpotTable = () => {
 		manualPagination: true,
 		manualSorting: true,
 		manualFiltering: true,
-		pageCount: Math.ceil(MOCK_SPOTS.length / PAGE_SIZE),
+		pageCount: data?.totalPages ?? -1,
 	});
 
 	return {
 		table,
-		isLoading: false,
-		error: null,
-		refetch: () => {},
+		isLoading,
+		error,
+		refetch,
 	};
 };

--- a/apps/admin/src/features/spots/services/createSpot.ts
+++ b/apps/admin/src/features/spots/services/createSpot.ts
@@ -1,39 +1,83 @@
 import { supabase } from '@/fsd/shared';
 import { ApiError } from '@/fsd/shared/lib/errors/apiError';
 import type { Spot } from '@jung/shared/types';
+import { uploadSpotImage } from '../lib/uploadImage';
 
-type CreateSpotInput = Omit<
-	Spot,
-	'id' | 'created_at' | 'updated_at' | 'likes' | 'liked_by'
->;
+export interface CreateSpotInput {
+	title: string;
+	description: string;
+	address: string;
+	files: File[];
+	category_id: string;
+	coordinates: {
+		lat: number;
+		lng: number;
+	};
+	tags?: string[];
+	tips?: string[];
+}
 
-export const createSpot = async (data: CreateSpotInput): Promise<Spot> => {
-	const { data: newSpot, error } = await supabase
-		.from('spots')
-		.insert([
-			{
-				title: data.title,
-				description: data.description,
-				address: data.address,
-				photos: data.photos,
-				coordinates: data.coordinates,
-				category_id: data.category_id,
-				tags: data.tags || [],
-				tips: data.tips || [],
-				likes: 0,
-				liked_by: [],
-			},
-		])
-		.select()
-		.single();
+export const createSpot = async (input: CreateSpotInput): Promise<Spot> => {
+	console.log(input, 'input');
 
-	if (error) {
-		throw ApiError.fromPostgrestError(error);
+	try {
+		const uploadedPhotos = await Promise.all(
+			input.files.map(async (file) => {
+				const { url } = await uploadSpotImage(file);
+
+				return { url };
+			}),
+		);
+
+		const { data: spot, error: spotError } = await supabase
+			.from('spots')
+			.insert([
+				{
+					title: input.title,
+					description: input.description,
+					address: input.address,
+					photos: uploadedPhotos,
+					category_id: input.category_id,
+					coordinates: input.coordinates,
+					tags: input.tags || [],
+					tips: input.tips || [],
+					likes: 0,
+					created_at: new Date().toISOString(),
+					updated_at: new Date().toISOString(),
+					liked_by: [],
+				},
+			])
+			.select()
+			.single();
+
+		console.log(spot, 'spot');
+
+		if (spotError) {
+			await Promise.all(
+				uploadedPhotos.map(async (photo) => {
+					const filePath = new URL(photo.url).pathname.split('/').pop();
+					if (filePath) {
+						await supabase.storage
+							.from('spots_images')
+							.remove([`uploads/${filePath}`]);
+					}
+				}),
+			);
+			throw ApiError.fromPostgrestError(spotError);
+		}
+
+		if (!spot) {
+			throw new ApiError('Failed to create spot', 'NO_DATA');
+		}
+
+		return spot;
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		throw new ApiError(
+			'An unexpected error occurred while creating the spot',
+			'UNKNOWN_ERROR',
+		);
 	}
-
-	if (!newSpot) {
-		throw new ApiError('Failed to create spot', 'INTERNAL_SERVER_ERROR');
-	}
-
-	return newSpot;
 };

--- a/apps/admin/src/features/spots/services/createSpot.ts
+++ b/apps/admin/src/features/spots/services/createSpot.ts
@@ -1,0 +1,39 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import type { Spot } from '@jung/shared/types';
+
+type CreateSpotInput = Omit<
+	Spot,
+	'id' | 'created_at' | 'updated_at' | 'likes' | 'liked_by'
+>;
+
+export const createSpot = async (data: CreateSpotInput): Promise<Spot> => {
+	const { data: newSpot, error } = await supabase
+		.from('spots')
+		.insert([
+			{
+				title: data.title,
+				description: data.description,
+				address: data.address,
+				photos: data.photos,
+				coordinates: data.coordinates,
+				category_id: data.category_id,
+				tags: data.tags || [],
+				tips: data.tips || [],
+				likes: 0,
+				liked_by: [],
+			},
+		])
+		.select()
+		.single();
+
+	if (error) {
+		throw ApiError.fromPostgrestError(error);
+	}
+
+	if (!newSpot) {
+		throw new ApiError('Failed to create spot', 'INTERNAL_SERVER_ERROR');
+	}
+
+	return newSpot;
+};

--- a/apps/admin/src/features/spots/services/deleteSpot.ts
+++ b/apps/admin/src/features/spots/services/deleteSpot.ts
@@ -1,0 +1,48 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+
+export const deleteSpot = async (id: string): Promise<void> => {
+	try {
+		const { data: spot, error: getError } = await supabase
+			.from('spots')
+			.select('photos')
+			.eq('id', id)
+			.single();
+
+		if (getError) {
+			throw ApiError.fromPostgrestError(getError);
+		}
+
+		if (!spot) {
+			throw new ApiError('Spot not found', 'NOT_FOUND');
+		}
+
+		const { error: deleteError } = await supabase
+			.from('spots')
+			.delete()
+			.eq('id', id);
+
+		if (deleteError) {
+			throw ApiError.fromPostgrestError(deleteError);
+		}
+
+		await Promise.all(
+			spot.photos.map(async (photo: { url: string }) => {
+				const filePath = new URL(photo.url).pathname.split('/').pop();
+				if (filePath) {
+					await supabase.storage
+						.from('spots_images')
+						.remove([`uploads/${filePath}`]);
+				}
+			}),
+		);
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		throw new ApiError(
+			'An unexpected error occurred while deleting the spot',
+			'UNKNOWN_ERROR',
+		);
+	}
+};

--- a/apps/admin/src/features/spots/services/getCategories.ts
+++ b/apps/admin/src/features/spots/services/getCategories.ts
@@ -1,0 +1,81 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import type { CategoriesResponse, CategoryWithCount } from '@jung/shared/types';
+
+export const fetchSpotCategories = async (): Promise<CategoriesResponse> => {
+	const { data: categories, error: categoriesError } = await supabase
+		.from('categories')
+		.select(`
+      id,
+      name,
+      description,
+      color,
+      parent_id,
+      type,
+      created_at
+    `)
+		.eq('type', 'spots')
+		.order('created_at');
+
+	if (categoriesError) {
+		throw ApiError.fromPostgrestError(categoriesError);
+	}
+
+	if (!categories) {
+		throw new ApiError('No categories found', 'NOT_FOUND');
+	}
+
+	const { data: spotCounts, error: spotCountsError } = await supabase
+		.from('spots')
+		.select('category_id')
+		.in(
+			'category_id',
+			categories.map((cat) => cat.id),
+		);
+
+	if (spotCountsError) {
+		throw ApiError.fromPostgrestError(spotCountsError);
+	}
+
+	const spotCountMap = (spotCounts || []).reduce(
+		(acc, spot) => {
+			acc[spot.category_id] = (acc[spot.category_id] || 0) + 1;
+			return acc;
+		},
+		{} as Record<string, number>,
+	);
+
+	const subCategoryMap = categories.reduce(
+		(acc, category) => {
+			if (category.parent_id) {
+				acc[category.parent_id] = (acc[category.parent_id] || 0) + 1;
+			}
+			return acc;
+		},
+		{} as Record<string, number>,
+	);
+
+	const processedCategories: CategoryWithCount[] = categories.map(
+		(category) => {
+			const directSpotCount = spotCountMap[category.id] || 0;
+			const subCount = subCategoryMap[category.id] || 0;
+
+			return {
+				...category,
+				description: category.description ?? '',
+				color: category.color ?? '#0142C0',
+				directPostCount: directSpotCount,
+				postCount: directSpotCount,
+				subCategoriesCount: subCount,
+			};
+		},
+	);
+
+	const result = {
+		mainCategories: processedCategories.filter((cat) => !cat.parent_id),
+		subCategories: processedCategories.filter((cat) => cat.parent_id),
+		allCategories: processedCategories,
+	};
+
+	return result;
+};

--- a/apps/admin/src/features/spots/services/getSpotById.ts
+++ b/apps/admin/src/features/spots/services/getSpotById.ts
@@ -1,0 +1,21 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import type { Spot } from '@jung/shared/types';
+
+export const getSpotById = async (id: string): Promise<Spot> => {
+	const { data: spot, error } = await supabase
+		.from('spots')
+		.select('*')
+		.eq('id', id)
+		.single();
+
+	if (error) {
+		throw ApiError.fromPostgrestError(error);
+	}
+
+	if (!spot) {
+		throw new ApiError('Spot not found', 'NOT_FOUND');
+	}
+
+	return spot;
+};

--- a/apps/admin/src/features/spots/services/getSpots.ts
+++ b/apps/admin/src/features/spots/services/getSpots.ts
@@ -1,0 +1,67 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import type { Spot } from '@jung/shared/types';
+
+interface SpotFilters {
+	page: number;
+	pageSize: number;
+	sortField?: keyof Spot;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+}
+
+export const fetchSpots = async ({
+	page,
+	pageSize,
+	sortField = 'created_at',
+	sortOrder = 'desc',
+	filter,
+}: SpotFilters): Promise<{
+	spots: Spot[];
+	totalCount: number;
+	totalPages: number;
+	hasMore: boolean;
+}> => {
+	const from = page * pageSize;
+	const to = from + pageSize - 1;
+
+	let query = supabase.from('spots').select('*', { count: 'exact' });
+
+	if (sortField) {
+		query = query.order(sortField, { ascending: sortOrder === 'asc' });
+	}
+
+	if (filter) {
+		query = query.or(
+			`name.ilike.%${filter}%,description.ilike.%${filter}%,address.ilike.%${filter}%`,
+		);
+	}
+
+	query = query.range(from, to);
+
+	const { data, error, count } = await query;
+
+	if (error) {
+		throw ApiError.fromPostgrestError(error);
+	}
+
+	const totalCount = count ?? 0;
+	const totalPages = Math.ceil(totalCount / pageSize);
+	const hasMore = page < totalPages - 1;
+
+	if (!data) {
+		return {
+			spots: [],
+			totalCount: 0,
+			totalPages: 0,
+			hasMore: false,
+		};
+	}
+
+	return {
+		spots: data,
+		totalCount,
+		totalPages,
+		hasMore,
+	};
+};

--- a/apps/admin/src/features/spots/services/updateSpot.ts
+++ b/apps/admin/src/features/spots/services/updateSpot.ts
@@ -1,0 +1,85 @@
+import { supabase } from '@/fsd/shared';
+import { ApiError } from '@/fsd/shared/lib/errors/apiError';
+import type { Spot, SpotImageUpload } from '@jung/shared/types';
+import { uploadSpotImage } from '../lib/uploadImage';
+
+// FIXME: 기존 SPOT 타입 재활용하기
+export interface UpdateSpotInput {
+	id: string;
+	title: string;
+	description: string;
+	address: string;
+	images: SpotImageUpload[];
+	category_id: string;
+	coordinates: {
+		lat: number;
+		lng: number;
+	};
+	tags?: string[];
+	tips?: string[];
+}
+
+export const updateSpot = async (input: UpdateSpotInput): Promise<Spot> => {
+	try {
+		const newImages = input.images.filter(
+			(img) => img.status === 'new' && img.file,
+		);
+		const uploadedPhotos = await Promise.all(
+			newImages.map(async (image) => {
+				const { url } = await uploadSpotImage(image.file!);
+				return { url };
+			}),
+		);
+
+		const remainingPhotos = input.images
+			.filter((img) => img.status === 'existing')
+			.map((img) => ({ url: img.url }));
+
+		const allPhotos = [...remainingPhotos, ...uploadedPhotos];
+
+		const { data: spot, error: spotError } = await supabase
+			.from('spots')
+			.update({
+				title: input.title,
+				description: input.description,
+				address: input.address,
+				photos: allPhotos,
+				category_id: input.category_id,
+				coordinates: input.coordinates,
+				tags: input.tags || [],
+				tips: input.tips || [],
+				updated_at: new Date().toISOString(),
+			})
+			.eq('id', input.id)
+			.select()
+			.single();
+
+		if (spotError) {
+			await Promise.all(
+				uploadedPhotos.map(async ({ url }) => {
+					const filePath = new URL(url).pathname.split('/').pop();
+					if (filePath) {
+						await supabase.storage
+							.from('spots_images')
+							.remove([`uploads/${filePath}`]);
+					}
+				}),
+			);
+			throw ApiError.fromPostgrestError(spotError);
+		}
+
+		if (!spot) {
+			throw new ApiError('Failed to update spot', 'NO_DATA');
+		}
+
+		return spot;
+	} catch (error) {
+		if (error instanceof ApiError) {
+			throw error;
+		}
+		throw new ApiError(
+			'An unexpected error occurred while updating the spot',
+			'UNKNOWN_ERROR',
+		);
+	}
+};

--- a/apps/admin/src/features/spots/ui/NewSpot.css.ts
+++ b/apps/admin/src/features/spots/ui/NewSpot.css.ts
@@ -33,7 +33,7 @@ export const formLayout = style({
 	display: 'flex',
 	gap: '32px',
 	marginBottom: '24px',
-	height: '500px',
+	minHeight: '500px',
 
 	'@media': {
 		'screen and (max-width: 768px)': {

--- a/apps/admin/src/features/spots/ui/NewSpot.tsx
+++ b/apps/admin/src/features/spots/ui/NewSpot.tsx
@@ -3,13 +3,17 @@ import { useLocation, useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { HiLocationMarker, HiTag } from 'react-icons/hi';
 import { MdAdd, MdDelete } from 'react-icons/md';
-import { CATEGORY_LABELS } from '../model/useSpotTable';
+import { useGetSpotCategories } from '../api/useGetSpotCategories';
+
 import * as styles from './NewSpot.css';
 
 export const NewSpot = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const isEditMode = location.pathname.includes('/spots/edit');
+
+	const { data: categoriesData, isLoading: categoriesLoading } =
+		useGetSpotCategories();
 
 	const [formData, setFormData] = useState<Partial<Spot>>({
 		tips: [''],
@@ -39,6 +43,10 @@ export const NewSpot = () => {
 			);
 		}
 	};
+
+	if (categoriesLoading) {
+		return <div>Loading categories...</div>;
+	}
 
 	return (
 		<div className={styles.pageWrapper}>
@@ -74,19 +82,19 @@ export const NewSpot = () => {
 								<label className={styles.label}>Category</label>
 								<div className={styles.selectWrapper}>
 									<select
-										value={formData.category || ''}
+										value={formData.category_id || ''}
 										onChange={(e) =>
 											setFormData((prev) => ({
 												...prev,
-												category: e.target.value as Spot['category'],
+												category_id: e.target.value,
 											}))
 										}
 										className={styles.select}
 									>
 										<option value=''>Select category</option>
-										{Object.entries(CATEGORY_LABELS).map(([value, label]) => (
-											<option key={value} value={value}>
-												{label}
+										{categoriesData?.allCategories.map((category) => (
+											<option key={category.id} value={category.id}>
+												{category.name}
 											</option>
 										))}
 									</select>

--- a/apps/admin/src/features/spots/ui/SpotCategoryManager.tsx
+++ b/apps/admin/src/features/spots/ui/SpotCategoryManager.tsx
@@ -265,7 +265,7 @@ export const SpotCategoryManager = () => {
 								)}
 								<div className={styles.spotInfo}>
 									<span className={styles.location}>{spot.location}</span>
-									<span className={styles.rating}>⭐ {spot.rating}</span>
+									{/* <span className={styles.rating}>⭐ {spot.rating}</span> */}
 								</div>
 							</div>
 							<div className={styles.cardFooter}>
@@ -296,15 +296,15 @@ export const SpotCategoryManager = () => {
 					</span>
 					<span className={styles.statLabel}>Total Reviews</span>
 				</div>
-				<div className={styles.statCard}>
-					<span className={styles.statValue}>
-						{(
-							categories.reduce((sum, cat) => sum + cat.rating, 0) /
-							categories.length
-						).toFixed(1)}
-					</span>
-					<span className={styles.statLabel}>Average Rating</span>
-				</div>
+				{/* <div className={styles.statCard}>
+          <span className={styles.statValue}>
+            {(
+              categories.reduce((sum, cat) => sum + cat.rating, 0) /
+              categories.length
+            ).toFixed(1)}
+          </span>
+          <span className={styles.statLabel}>Average Rating</span>
+        </div> */}
 			</div>
 
 			<div className={styles.mainSection}>

--- a/apps/admin/src/features/spots/ui/SpotTable/ImageUploader.css.ts
+++ b/apps/admin/src/features/spots/ui/SpotTable/ImageUploader.css.ts
@@ -1,0 +1,126 @@
+import { style } from '@vanilla-extract/css';
+
+export const wrapper = style({
+	width: '100%',
+	borderRadius: '12px',
+
+	background: '#f8f9fa',
+	border: '1px solid #e9ecef',
+});
+
+export const imageGrid = style({
+	display: 'grid',
+	gap: '8px',
+	gridTemplateColumns: '1fr',
+	'@media': {
+		'screen and (min-width: 768px)': {
+			gridTemplateColumns: 'repeat(2, 1fr)',
+		},
+	},
+	selectors: {
+		'&[data-count="0"]': {
+			gridTemplateColumns: '1fr',
+		},
+		'&[data-count="1"]': {
+			gridTemplateColumns: '1fr 1fr',
+		},
+		'&[data-count="2"]': {
+			gridTemplateColumns: 'repeat(2, 1fr)',
+		},
+		'&[data-count="3"]': {
+			gridTemplateAreas: `
+				"img1 img2"
+				"img3 img4"
+			`,
+		},
+		'&[data-count="4"]': {
+			gridTemplateAreas: `
+				"img1 img2"
+				"img3 img4"
+			`,
+		},
+	},
+});
+
+export const imageWrapper = style({
+	position: 'relative',
+	aspectRatio: '16/9',
+	borderRadius: '8px',
+	overflow: 'hidden',
+	boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)',
+	transition: 'transform 0.2s ease',
+	background: 'white',
+	':hover': {
+		transform: 'scale(1.01)',
+	},
+});
+
+export const image = style({
+	width: '100%',
+	height: '100%',
+	objectFit: 'cover',
+});
+
+export const deleteButton = style({
+	position: 'absolute',
+	top: '12px',
+	right: '12px',
+	background: 'rgba(0, 0, 0, 0.6)',
+	color: 'white',
+	border: 'none',
+	borderRadius: '50%',
+	padding: '8px',
+	cursor: 'pointer',
+	transition: 'all 0.2s ease',
+	opacity: 0,
+	transform: 'scale(0.9)',
+	selectors: {
+		[`${imageWrapper}:hover &`]: {
+			opacity: 1,
+			transform: 'scale(1)',
+		},
+	},
+	':hover': {
+		background: 'rgba(0, 0, 0, 0.8)',
+	},
+});
+
+export const uploadButton = style({
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+	justifyContent: 'center',
+	gap: '8px',
+	aspectRatio: '16/9',
+	border: '2px dashed #dee2e6',
+	borderRadius: '12px',
+	cursor: 'pointer',
+	background: 'white',
+	transition: 'all 0.2s ease',
+	padding: '24px',
+	':hover': {
+		borderColor: '#228be6',
+		background: '#f8f9fa',
+	},
+});
+
+export const uploadIcon = style({
+	fontSize: '32px',
+	color: '#adb5bd',
+	marginBottom: '4px',
+});
+
+export const uploadText = style({
+	fontSize: '15px',
+	fontWeight: 500,
+	color: '#495057',
+});
+
+export const uploadSubtext = style({
+	fontSize: '13px',
+	color: '#868e96',
+});
+
+export const fileInput = style({
+	display: 'none',
+});

--- a/apps/admin/src/features/spots/ui/SpotTable/ImageUploader.tsx
+++ b/apps/admin/src/features/spots/ui/SpotTable/ImageUploader.tsx
@@ -1,0 +1,96 @@
+import { useToast } from '@jung/design-system/components';
+import { useState } from 'react';
+import { MdDelete, MdPhoto } from 'react-icons/md';
+import * as styles from './ImageUploader.css';
+
+interface ImageUploaderProps {
+	images: { id: string; url: string }[];
+	onChange: (images: { id: string; url: string }[]) => void;
+	maxImages?: number;
+}
+
+export const ImageUploader = ({
+	images,
+	onChange,
+	maxImages = 4,
+}: ImageUploaderProps) => {
+	const showToast = useToast();
+	const [isUploading, setIsUploading] = useState(false);
+
+	const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = e.target.files;
+		if (!files) return;
+
+		if (images.length + files.length > maxImages) {
+			showToast(
+				`최대 ${maxImages}개의 이미지만 업로드할 수 있습니다.`,
+				'error',
+			);
+			return;
+		}
+
+		setIsUploading(true);
+		try {
+			// TODO: Implement actual image upload logic
+			const newImages = Array.from(files).map((file) => ({
+				id: Math.random().toString(),
+				url: URL.createObjectURL(file),
+			}));
+
+			onChange([...images, ...newImages]);
+		} catch (error) {
+			showToast('이미지 업로드에 실패했습니다.', 'error');
+		}
+		setIsUploading(false);
+	};
+
+	const handleRemoveImage = (id: string) => {
+		onChange(images.filter((img) => img.id !== id));
+	};
+
+	return (
+		<div className={styles.wrapper}>
+			<div className={styles.imageGrid} data-count={images.length}>
+				{images.map((image, index) => (
+					<div
+						key={image.id}
+						className={styles.imageWrapper}
+						data-area={`img${index + 1}`}
+					>
+						<img src={image.url} alt='' className={styles.image} />
+						<button
+							type='button'
+							onClick={() => handleRemoveImage(image.id)}
+							className={styles.deleteButton}
+							aria-label='Delete image'
+						>
+							<MdDelete size={20} />
+						</button>
+					</div>
+				))}
+				{images.length < maxImages && (
+					<label
+						className={styles.uploadButton}
+						data-area={`img${images.length + 1}`}
+					>
+						<input
+							type='file'
+							accept='image/*'
+							multiple
+							onChange={handleImageUpload}
+							disabled={isUploading}
+							className={styles.fileInput}
+						/>
+						<MdPhoto className={styles.uploadIcon} />
+						<span className={styles.uploadText}>
+							{images.length === 0 ? 'Add Image' : 'Add More'}
+						</span>
+						<span className={styles.uploadSubtext}>
+							{isUploading ? 'Uploading...' : `${images.length}/${maxImages}`}
+						</span>
+					</label>
+				)}
+			</div>
+		</div>
+	);
+};

--- a/apps/admin/src/features/spots/ui/SpotTable/SpotTable.css.ts
+++ b/apps/admin/src/features/spots/ui/SpotTable/SpotTable.css.ts
@@ -221,12 +221,12 @@ export const categoryBadge = style({
 	color: '#0142C0',
 });
 
-export const rating = style({
-	display: 'inline-flex',
-	alignItems: 'center',
-	gap: '4px',
-	color: '#ff9500',
-});
+// export const rating = style({
+// 	display: 'inline-flex',
+// 	alignItems: 'center',
+// 	gap: '4px',
+// 	color: '#ff9500',
+// });
 
 export const thumbnail = style({
 	width: '60px',

--- a/apps/admin/src/features/spots/ui/SpotTable/SpotTable.css.ts
+++ b/apps/admin/src/features/spots/ui/SpotTable/SpotTable.css.ts
@@ -1,3 +1,4 @@
+import { palette } from '@jung/design-system/tokens';
 import { style } from '@vanilla-extract/css';
 
 export const tableAction = style({
@@ -5,39 +6,76 @@ export const tableAction = style({
 	justifyContent: 'space-between',
 	alignItems: 'center',
 	marginBottom: '24px',
+	borderBottom: '1px solid #F1F5F9',
+	backgroundColor: '#F8FAFC',
+	flexWrap: 'wrap',
+	gap: '16px',
 });
 
 export const searchInput = style({
+	width: '280px',
 	padding: '8px 16px',
-	border: '1px solid #e2e8f0',
-	borderRadius: '6px',
+	borderRadius: '8px',
+	border: '1px solid #E2E8F0',
+	backgroundColor: 'white',
 	fontSize: '14px',
-	width: '320px',
 	transition: 'all 0.2s ease',
+	boxShadow: '0 1px 2px rgba(0, 0, 0, 0.05)',
 
 	':focus': {
 		outline: 'none',
-		borderColor: '#0142C0',
-		boxShadow: '0 0 0 2px rgba(1, 66, 192, 0.1)',
+		borderColor: palette.primary,
+		boxShadow: '0 0 0 3px rgba(1, 66, 192, 0.1)',
+	},
+
+	'::placeholder': {
+		color: '#94A3B8',
+	},
+
+	'@media': {
+		'(max-width: 1024px)': {
+			width: '200px',
+			fontSize: '13px',
+			padding: '10px 16px',
+		},
+
+		'(max-width: 768px)': {
+			width: '100%',
+			maxWidth: '400px',
+			margin: '0 auto',
+		},
+
+		'(max-width: 640px)': {
+			fontSize: '14px',
+			padding: '12px 16px',
+			maxWidth: 'none',
+		},
+
+		'(max-width: 480px)': {
+			borderRadius: '8px',
+			padding: '10px 14px',
+		},
 	},
 });
-
 export const newButton = style({
-	display: 'inline-flex',
+	display: 'flex',
 	alignItems: 'center',
 	gap: '8px',
 	padding: '8px 16px',
-	background: '#0142C0',
+	borderRadius: '8px',
+	backgroundColor: palette.primary,
 	color: 'white',
 	border: 'none',
-	borderRadius: '6px',
 	fontSize: '14px',
 	fontWeight: '500',
 	cursor: 'pointer',
 	transition: 'all 0.2s ease',
+	boxShadow: '0 1px 2px rgba(1, 66, 192, 0.1)',
 
 	':hover': {
-		background: '#0031A0',
+		backgroundColor: '#0052CC',
+		transform: 'translateY(-1px)',
+		boxShadow: '0 4px 6px rgba(1, 66, 192, 0.1)',
 	},
 });
 
@@ -54,59 +92,71 @@ export const table = style({
 });
 
 export const th = style({
-	padding: '12px 16px',
-	textAlign: 'center',
-	fontSize: '14px',
-	fontWeight: '500',
-	color: '#64748b',
-	background: '#f8fafc',
-	borderBottom: '1px solid #e2e8f0',
-	position: 'relative',
+	// display: 'flex',
+	// alignItems: 'center',
+	// justifyContent: 'center',
+
+	padding: '8px 16px',
+	backgroundColor: 'white',
+	borderBottom: '1px solid #F1F5F9',
+
+	whiteSpace: 'nowrap',
+	fontSize: '13px',
+	fontWeight: '600',
+	color: '#64748B',
+	transition: 'all 0.2s ease',
+
+	'@media': {
+		'(max-width: 768px)': {
+			padding: '12px 16px',
+			fontSize: '12px',
+		},
+	},
 });
 
 export const row = style({
+	transition: 'all 0.2s ease',
+	backgroundColor: 'white',
+
 	':hover': {
-		background: '#f8fafc',
+		backgroundColor: '#F8FAFC',
 	},
 });
 
 export const td = style({
-	padding: '12px 16px',
+	padding: '16px 24px',
+	borderBottom: '1px solid #F1F5F9',
 	fontSize: '14px',
-	borderBottom: '1px solid #e2e8f0',
-	whiteSpace: 'nowrap',
-	overflow: 'hidden',
-	textOverflow: 'ellipsis',
-	maxWidth: '200px',
-	textAlign: 'center',
+	color: '#334155',
+	transition: 'all 0.2s ease',
 	verticalAlign: 'middle',
+	textAlign: 'center',
+
+	'@media': {
+		'(max-width: 768px)': {
+			padding: '12px 16px',
+			fontSize: '13px',
+		},
+	},
 });
 
 export const actionButton = style({
-	display: 'inline-flex',
-	alignItems: 'center',
-	justifyContent: 'center',
-	width: '32px',
-	height: '32px',
-	padding: '0',
-	background: 'transparent',
-	border: '1px solid #e2e8f0',
-	borderRadius: '6px',
-	color: '#64748b',
+	padding: '10px',
+	borderRadius: '10px',
+	backgroundColor: '#F8FAFC',
+	border: '1px solid #E2E8F0',
+	color: '#64748B',
 	cursor: 'pointer',
 	transition: 'all 0.2s ease',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
 
-	selectors: {
-		'&:hover': {
-			background: '#f1f5f9',
-			borderColor: '#cbd5e1',
-			color: '#0142C0',
-		},
-		'&:has(svg[data-icon="trash"]):hover': {
-			background: '#fee2e2',
-			borderColor: '#fecaca',
-			color: '#ef4444',
-		},
+	':hover': {
+		backgroundColor: '#F1F5F9',
+		color: '#0142C0',
+		borderColor: '#CBD5E1',
+		transform: 'translateY(-1px)',
 	},
 });
 
@@ -119,31 +169,46 @@ export const footer = style({
 
 export const pagination = style({
 	display: 'flex',
-	gap: '8px',
+	justifyContent: 'space-between',
 	alignItems: 'center',
+	padding: '16px 24px',
+	borderTop: '1px solid #F1F5F9',
+	backgroundColor: '#F8FAFC',
+	flexWrap: 'wrap',
+	gap: '16px',
+
+	'@media': {
+		'(max-width: 768px)': {
+			flexDirection: 'column',
+			alignItems: 'center',
+			padding: '16px',
+		},
+	},
 });
 
 export const pageButton = style({
-	padding: '6px 12px',
-	border: '1px solid #e2e8f0',
-	borderRadius: '6px',
-	background: 'transparent',
-	color: '#64748b',
+	padding: '8px 16px',
+	borderRadius: '10px',
+	border: '1px solid #E2E8F0',
+	backgroundColor: 'white',
+	color: '#64748B',
 	fontSize: '14px',
 	cursor: 'pointer',
 	transition: 'all 0.2s ease',
+	display: 'flex',
+	alignItems: 'center',
+	gap: '4px',
 
-	':hover': {
-		background: '#f1f5f9',
-		borderColor: '#cbd5e1',
+	'@media': {
+		'(max-width: 768px)': {
+			padding: '6px 12px',
+			fontSize: '13px',
+		},
 	},
 
-	selectors: {
-		'&[data-active="true"]': {
-			background: '#0142C0',
-			borderColor: '#0142C0',
-			color: 'white',
-		},
+	':hover': {
+		backgroundColor: '#F1F5F9',
+		borderColor: '#CBD5E1',
 	},
 });
 

--- a/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
+++ b/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
@@ -28,6 +28,8 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 			{table.getRowModel().rows.map((row) => {
 				const spot = row.original as Spot;
 
+				console.log(spot, 'spot');
+
 				const category = categoriesData?.allCategories.find(
 					(cat) => cat.id === spot.category_id,
 				);
@@ -48,7 +50,7 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 								}`}
 							>
 								{cell.column.id === 'photos' ? (
-									<ImageCell url={spot.photos[0]?.url} alt={spot.title} />
+									<ImageCell url={spot.photos[0].url} alt={spot.title} />
 								) : cell.column.id === 'created_at' ? (
 									<DateCell date={spot.created_at} />
 								) : cell.column.id === 'category' ? (

--- a/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
+++ b/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
@@ -2,14 +2,12 @@ import type { Spot } from '@jung/shared/types';
 import { Link } from '@tanstack/react-router';
 import { type Table, flexRender } from '@tanstack/react-table';
 import { FaEdit, FaTrash } from 'react-icons/fa';
-import { MdStar } from 'react-icons/md';
 import { useDeleteSpot } from '../../api/useDeleteSpot';
-import { CATEGORY_LABELS } from '../../model/useSpotTable';
+import { useGetSpotCategories } from '../../api/useGetSpotCategories';
 import * as styles from './SpotTable.css';
-import { CoordinatesCell } from './cells/CoordinatesCell';
+import { CategoryCell } from './cells/CategoryCell';
 import { DateCell } from './cells/DateCell';
 import { ImageCell } from './cells/ImageCell';
-import { TipsCell } from './cells/TipsCell';
 
 interface TableBodyProps<T> {
 	table: Table<T>;
@@ -17,6 +15,7 @@ interface TableBodyProps<T> {
 
 export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 	const deleteSpotMutation = useDeleteSpot();
+	const { data: categoriesData } = useGetSpotCategories();
 
 	const handleDelete = (id: string) => {
 		if (window.confirm('이 장소를 삭제하시겠습니까?')) {
@@ -28,6 +27,10 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 		<tbody>
 			{table.getRowModel().rows.map((row) => {
 				const spot = row.original as Spot;
+
+				const category = categoriesData?.allCategories.find(
+					(cat) => cat.id === spot.category_id,
+				);
 
 				return (
 					<tr key={row.id} className={styles.row}>
@@ -46,23 +49,10 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 							>
 								{cell.column.id === 'photos' ? (
 									<ImageCell url={spot.photos[0]?.url} alt={spot.title} />
-								) : cell.column.id === 'coordinates' ? (
-									<CoordinatesCell
-										lat={spot.coordinates.lat}
-										lng={spot.coordinates.lng}
-									/>
 								) : cell.column.id === 'created_at' ? (
 									<DateCell date={spot.created_at} />
-								) : cell.column.id === 'tips' ? (
-									<TipsCell tips={spot.tips || []} />
 								) : cell.column.id === 'category' ? (
-									<span className={styles.categoryBadge}>
-										{CATEGORY_LABELS[spot.category]}
-									</span>
-								) : cell.column.id === 'rating' ? (
-									<span className={styles.rating}>
-										<MdStar /> {spot.rating.toFixed(1)}
-									</span>
+									<CategoryCell category={category} />
 								) : (
 									flexRender(cell.column.columnDef.cell, cell.getContext())
 								)}
@@ -70,7 +60,7 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 						))}
 						<td className={styles.td}>
 							<div style={{ display: 'flex', gap: '8px' }}>
-								<Link to={'/spots/edit/$spotId'} params={{ spotId: spot.id }}>
+								<Link to={'/spots/$spotId/edit'} params={{ spotId: spot.id }}>
 									<button className={styles.actionButton}>
 										<FaEdit size={16} />
 									</button>

--- a/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
+++ b/apps/admin/src/features/spots/ui/SpotTable/TableBody.tsx
@@ -42,7 +42,7 @@ export const TableBody = <T,>({ table }: TableBodyProps<T>) => {
 									cell.column.id === 'address' ||
 									cell.column.id === 'tips'
 										? styles.textAlignLeft
-										: cell.column.id === 'likes' || cell.column.id === 'rating'
+										: cell.column.id === 'likes'
 										  ? styles.textAlignRight
 										  : ''
 								}`}

--- a/apps/admin/src/features/spots/ui/SpotTable/cells/CategoryCell.tsx
+++ b/apps/admin/src/features/spots/ui/SpotTable/cells/CategoryCell.tsx
@@ -1,0 +1,24 @@
+import { Typography } from '@jung/design-system/components';
+import type { CategoryWithCount } from '@jung/shared/types';
+
+interface CategoryCellProps {
+	category?: CategoryWithCount;
+}
+
+export const CategoryCell = ({ category }: CategoryCellProps) => {
+	if (!category) return null;
+
+	return (
+		<Typography.Text
+			level={3}
+			style={{
+				color: category.color || '#000000',
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: '4px',
+			}}
+		>
+			{category.name}
+		</Typography.Text>
+	);
+};

--- a/apps/admin/src/routeTree.gen.ts
+++ b/apps/admin/src/routeTree.gen.ts
@@ -23,8 +23,8 @@ import { Route as GalleryPhotosIndexImport } from './routes/gallery/photos/index
 import { Route as GalleryPhotosNewIndexImport } from './routes/gallery/photos/new/index';
 import { Route as GuestbookIndexImport } from './routes/guestbook/index';
 import { Route as IndexImport } from './routes/index';
+import { Route as SpotsSpotIdEditImport } from './routes/spots/$spotId/edit';
 import { Route as SpotsCategoriesIndexImport } from './routes/spots/categories/index';
-import { Route as SpotsEditSpotIdImport } from './routes/spots/edit/$spotId';
 import { Route as SpotsIndexImport } from './routes/spots/index';
 import { Route as SpotsNewIndexImport } from './routes/spots/new/index';
 
@@ -85,8 +85,8 @@ const BlogCategoriesIndexRoute = BlogCategoriesIndexImport.update({
 	getParentRoute: () => rootRoute,
 } as any);
 
-const SpotsEditSpotIdRoute = SpotsEditSpotIdImport.update({
-	path: '/spots/edit/$spotId',
+const SpotsSpotIdEditRoute = SpotsSpotIdEditImport.update({
+	path: '/spots/$spotId/edit',
 	getParentRoute: () => rootRoute,
 } as any);
 
@@ -164,11 +164,11 @@ declare module '@tanstack/react-router' {
 			preLoaderRoute: typeof GalleryCollectionsCollectionIdImport;
 			parentRoute: typeof rootRoute;
 		};
-		'/spots/edit/$spotId': {
-			id: '/spots/edit/$spotId';
-			path: '/spots/edit/$spotId';
-			fullPath: '/spots/edit/$spotId';
-			preLoaderRoute: typeof SpotsEditSpotIdImport;
+		'/spots/$spotId/edit': {
+			id: '/spots/$spotId/edit';
+			path: '/spots/$spotId/edit';
+			fullPath: '/spots/$spotId/edit';
+			preLoaderRoute: typeof SpotsSpotIdEditImport;
 			parentRoute: typeof rootRoute;
 		};
 		'/blog/categories/': {
@@ -240,7 +240,7 @@ export const routeTree = rootRoute.addChildren({
 	SpotsIndexRoute,
 	BlogEditPostIdRoute,
 	GalleryCollectionsCollectionIdRoute,
-	SpotsEditSpotIdRoute,
+	SpotsSpotIdEditRoute,
 	BlogCategoriesIndexRoute,
 	BlogNewIndexRoute,
 	GalleryCollectionsIndexRoute,
@@ -266,7 +266,7 @@ export const routeTree = rootRoute.addChildren({
         "/spots/",
         "/blog/edit/$postId",
         "/gallery/collections/$collectionId",
-        "/spots/edit/$spotId",
+        "/spots/$spotId/edit",
         "/blog/categories/",
         "/blog/new/",
         "/gallery/collections/",
@@ -298,8 +298,8 @@ export const routeTree = rootRoute.addChildren({
     "/gallery/collections/$collectionId": {
       "filePath": "gallery/collections/$collectionId.tsx"
     },
-    "/spots/edit/$spotId": {
-      "filePath": "spots/edit/$spotId.tsx"
+    "/spots/$spotId/edit": {
+      "filePath": "spots/$spotId/edit.tsx"
     },
     "/blog/categories/": {
       "filePath": "blog/categories/index.tsx"

--- a/apps/admin/src/routes/spots/$spotId/edit.tsx
+++ b/apps/admin/src/routes/spots/$spotId/edit.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/spots/$spotId/edit')({
+	component: () => <div>Hello /spots/$spotId/edit!</div>,
+});

--- a/apps/admin/src/routes/spots/$spotId/edit.tsx
+++ b/apps/admin/src/routes/spots/$spotId/edit.tsx
@@ -1,5 +1,17 @@
+import { NewSpot } from '@/fsd/features/spots/ui/NewSpot';
 import { createFileRoute } from '@tanstack/react-router';
 
+interface SearchParams {
+	mode?: 'edit';
+	spotId?: string;
+}
+
 export const Route = createFileRoute('/spots/$spotId/edit')({
-	component: () => <div>Hello /spots/$spotId/edit!</div>,
+	component: NewSpot,
+	validateSearch: (search: Record<string, unknown>): SearchParams => {
+		return {
+			mode: search.mode === 'edit' ? 'edit' : undefined,
+			spotId: typeof search.spotId === 'string' ? search.spotId : undefined,
+		};
+	},
 });

--- a/apps/admin/src/routes/spots/edit/$spotId.tsx
+++ b/apps/admin/src/routes/spots/edit/$spotId.tsx
@@ -1,5 +1,0 @@
-import { createFileRoute } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/spots/edit/$spotId')({
-	component: () => <div>Hello /spots/edit/$spotId!</div>,
-});

--- a/apps/admin/src/shared/config/queryKey.ts
+++ b/apps/admin/src/shared/config/queryKey.ts
@@ -10,7 +10,7 @@ export const postKeys = {
 };
 
 export const categoryKeys = {
-	all: (type: 'blog' | 'spot') => ['categories', type] as const,
+	all: (type: 'blog' | 'spots') => ['categories', type] as const,
 };
 
 export const photoKeys = {

--- a/apps/admin/src/views/spots/ui/SpotPage.tsx
+++ b/apps/admin/src/views/spots/ui/SpotPage.tsx
@@ -14,10 +14,10 @@ export const SpotPage = () => {
 					<span className={styles.statLabel}>Categories</span>
 				</div>
 
-				<div className={styles.statCard}>
+				{/* <div className={styles.statCard}>
 					<span className={styles.statValue}>4.8</span>
 					<span className={styles.statLabel}>Avg Rating</span>
-				</div>
+				</div> */}
 			</div>
 			<SpotTable />
 		</div>

--- a/apps/server/routes/spot.ts
+++ b/apps/server/routes/spot.ts
@@ -7,11 +7,11 @@ export const spotRouter = router({
 	getAllSpots: publicProcedure
 		.input(SpotQueryParamsSchema)
 		.query(async ({ input }) => {
-			const { limit, cat, sort, q, cursor } = input;
+			const { limit, category_id, sort, q, cursor } = input;
 			return spotsService.findMany({
 				limit,
 				cursor,
-				cat,
+				category_id,
 				sort,
 				q,
 			});

--- a/apps/server/services/spot.ts
+++ b/apps/server/services/spot.ts
@@ -10,15 +10,15 @@ export const spotsService = {
 	async findMany({
 		limit,
 		cursor,
-		cat,
+		category_id,
 		q: search,
 		sort = 'latest',
 	}: SpotQueryParams): Promise<SpotQueryResult> {
 		try {
 			let query = supabase.from('spots').select('*', { count: 'exact' });
 
-			if (cat && cat !== 'all') {
-				query = query.eq('category', cat);
+			if (category_id && category_id !== 'all') {
+				query = query.eq('category_id', category_id);
 			}
 
 			if (search) {
@@ -27,8 +27,8 @@ export const spotsService = {
 				);
 			}
 
-			if (sort === 'rating') {
-				query = query.order('rating', { ascending: false });
+			if (sort === 'popular') {
+				query = query.order('likes', { ascending: false });
 			} else {
 				query = query.order('id', { ascending: false });
 			}

--- a/apps/web/app/(routing)/[lang]/spots/page.tsx
+++ b/apps/web/app/(routing)/[lang]/spots/page.tsx
@@ -1,7 +1,7 @@
 import { SpotList } from '@/fsd/features/spots';
 import { HydrateClient, trpc } from '@/fsd/shared/index.server';
 
-type Sort = 'latest' | 'rating';
+type Sort = 'latest' | 'oldest' | 'popular';
 
 type PageProps = {
 	searchParams: { [key: string]: string | string[] | undefined };
@@ -10,13 +10,13 @@ type PageProps = {
 export default function SpotsPage({ searchParams }: PageProps) {
 	const sort = (searchParams.sort as Sort) || 'latest';
 	const q = (searchParams.q as string) || '';
-	const cat = (searchParams.cat as string) || 'all';
+	const category_id = (searchParams.category_id as string) || 'all';
 
 	void trpc.spot.getAllSpots.prefetchInfinite({
 		limit: 12,
 		sort,
 		q,
-		cat,
+		category_id,
 	});
 
 	return (

--- a/apps/web/src/features/spots/api/useGetSpots.ts
+++ b/apps/web/src/features/spots/api/useGetSpots.ts
@@ -1,19 +1,19 @@
 import { trpc } from '@/fsd/shared';
 
 type QueryParams = {
-	cat?: string;
-	sort?: 'latest' | 'oldest' | 'popular' | 'rating';
+	category_id?: string;
+	sort?: 'latest' | 'oldest' | 'popular';
 	q?: string;
 };
 
 export function useGetSpots(params: QueryParams) {
-	const { sort = 'latest', cat, q = '' } = params;
+	const { sort = 'latest', category_id, q = '' } = params;
 
 	return trpc.spot.getAllSpots.useSuspenseInfiniteQuery(
 		{
 			limit: 12,
 			sort,
-			cat,
+			category_id,
 			q,
 		},
 		{

--- a/apps/web/src/features/spots/ui/CategoryIcon.tsx
+++ b/apps/web/src/features/spots/ui/CategoryIcon.tsx
@@ -1,52 +1,51 @@
-import type { SpotCategory } from '@jung/shared/types';
-import {
-	MdForest,
-	MdLocalCafe,
-	MdLocationCity,
-	MdNightlife,
-	MdPark,
-	MdStorefront,
-	MdTempleHindu,
-	MdTheaterComedy,
-} from 'react-icons/md';
+// import {
+//   MdForest,
+//   MdLocalCafe,
+//   MdLocationCity,
+//   MdNightlife,
+//   MdPark,
+//   MdStorefront,
+//   MdTempleHindu,
+//   MdTheaterComedy,
+// } from 'react-icons/md';
 
-interface CategoryIconProps {
-	category: SpotCategory;
-}
+// interface CategoryIconProps {
+//   category: SpotCategory;
+// }
 
-const getCategoryIcon = (category: SpotCategory) => {
-	const iconProps = {
-		size: 20,
-		color: 'currentColor',
-		style: {
-			filter: 'drop-shadow(0 1px 1px rgba(0,0,0,0.1))',
-		},
-	};
+// const getCategoryIcon = (category: SpotCategory) => {
+//   const iconProps = {
+//     size: 20,
+//     color: 'currentColor',
+//     style: {
+//       filter: 'drop-shadow(0 1px 1px rgba(0,0,0,0.1))',
+//     },
+//   };
 
-	switch (category) {
-		case 'nature':
-			return <MdForest {...iconProps} />;
-		case 'landmark':
-			return <MdLocationCity {...iconProps} />;
-		case 'historic':
-			return <MdTempleHindu {...iconProps} />;
-		case 'culture':
-			return <MdTheaterComedy {...iconProps} />;
-		case 'night':
-			return <MdNightlife {...iconProps} />;
-		case 'street':
-			return <MdStorefront {...iconProps} />;
-		case 'park':
-			return <MdPark {...iconProps} />;
-		case 'local':
-			return <MdLocalCafe {...iconProps} />;
-		default:
-			return <MdLocationCity {...iconProps} />;
-	}
-};
+//   switch (category) {
+//     case 'nature':
+//       return <MdForest {...iconProps} />;
+//     case 'landmark':
+//       return <MdLocationCity {...iconProps} />;
+//     case 'historic':
+//       return <MdTempleHindu {...iconProps} />;
+//     case 'culture':
+//       return <MdTheaterComedy {...iconProps} />;
+//     case 'night':
+//       return <MdNightlife {...iconProps} />;
+//     case 'street':
+//       return <MdStorefront {...iconProps} />;
+//     case 'park':
+//       return <MdPark {...iconProps} />;
+//     case 'local':
+//       return <MdLocalCafe {...iconProps} />;
+//     default:
+//       return <MdLocationCity {...iconProps} />;
+//   }
+// };
 
-const CategoryIcon = ({ category }: CategoryIconProps) => {
-	return getCategoryIcon(category);
-};
+// const CategoryIcon = ({ category }: CategoryIconProps) => {
+//   return getCategoryIcon(category);
+// };
 
-export default CategoryIcon;
+// export default CategoryIcon;

--- a/apps/web/src/features/spots/ui/CustomMarker.tsx
+++ b/apps/web/src/features/spots/ui/CustomMarker.tsx
@@ -1,13 +1,13 @@
 import { useMarkerVisibility } from '@/fsd/features/spots/model';
-import type { SpotCategory } from '@jung/shared/types';
+// import type { SpotCategory } from '@jung/shared/types';
 import { Marker, OverlayView } from '@react-google-maps/api';
 import { useState } from 'react';
-import CategoryIcon from './CategoryIcon';
+// import CategoryIcon from './CategoryIcon';
 import * as styles from './SpotMap.css';
 
 interface CustomMarkerProps {
 	position: google.maps.LatLngLiteral;
-	category: SpotCategory;
+	// category: SpotCategory;
 	isSelected: boolean;
 	title: string;
 	onClick: () => void;
@@ -17,7 +17,7 @@ interface CustomMarkerProps {
 
 const CustomMarker = ({
 	position,
-	category,
+	// category,
 	isSelected,
 	onClick,
 	title,
@@ -57,21 +57,21 @@ const CustomMarker = ({
 						{isHovered && !isSelected && (
 							<div className={styles.markerTooltip}>
 								<div className={styles.tooltipCategory}>
-									<CategoryIcon category={category} />
-									<span>{category}</span>
+									{/* <CategoryIcon category={category} /> */}
+									{/* <span>{category}</span> */}
 								</div>
 								<div className={styles.tooltipTitle}>{title}</div>
 							</div>
 						)}
 						<div
 							className={styles.customMarker({
-								category,
+								// category,
 								selected: isSelected,
 							})}
 							onClick={handleClick}
 						>
 							<div className={styles.markerIcon}>
-								<CategoryIcon category={category} />
+								{/* <CategoryIcon category={category} /> */}
 							</div>
 						</div>
 					</div>

--- a/apps/web/src/features/spots/ui/MarkerCluster.tsx
+++ b/apps/web/src/features/spots/ui/MarkerCluster.tsx
@@ -57,7 +57,7 @@ const MarkerCluster = ({
 							key={markerSpot.id}
 							title={markerSpot.title}
 							position={markerSpot.coordinates}
-							category={markerSpot.category}
+							// category={markerSpot.category}
 							isSelected={selectedMarkerId === markerSpot.id}
 							onClick={() => handleMarkerClick(markerSpot)}
 							clusterer={clusterer}

--- a/apps/web/src/features/spots/ui/SpotCard.tsx
+++ b/apps/web/src/features/spots/ui/SpotCard.tsx
@@ -7,7 +7,6 @@ import * as styles from './SpotCard.css';
 import type { Spot } from '@jung/shared/types';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
 import { useToggleSpotLike } from '../model';
-import { StarRating } from './StarRating';
 
 interface SpotCardProps {
 	spot: Spot;
@@ -80,7 +79,7 @@ export function SpotCard({ spot, variant = 'default' }: SpotCardProps) {
 						</Card.Description>
 					)}
 					<Card.Actions className={styles.footer}>
-						<StarRating value={spot.rating} size='sm' />
+						{/* <StarRating value={spot.likes} size="sm" /> */}
 					</Card.Actions>
 				</Card.Content>
 			</Card>

--- a/apps/web/src/features/spots/ui/SpotContent.tsx
+++ b/apps/web/src/features/spots/ui/SpotContent.tsx
@@ -19,7 +19,7 @@ type SpotContentProps = {
 	setIsListVisible: Dispatch<SetStateAction<boolean>>;
 };
 
-type Sort = 'latest' | 'rating' | 'popular' | 'oldest';
+type Sort = 'latest' | 'popular' | 'oldest';
 
 export const SpotContent = ({
 	isMapView,
@@ -27,11 +27,11 @@ export const SpotContent = ({
 	setIsListVisible,
 }: SpotContentProps) => {
 	const searchParams = useSearchParams();
-	const cat = searchParams.get('cat') || 'all';
+	const category_id = searchParams.get('category_id') || 'all';
 	const sort = (searchParams.get('sort') as Sort) || 'latest';
 	const q = searchParams.get('q') || '';
 
-	const [data, query] = useGetSpots({ cat, sort, q });
+	const [data, query] = useGetSpots({ category_id, sort, q });
 	const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
 
 	const { ref, inView } = useInView();

--- a/apps/web/src/features/spots/ui/SpotDetail.tsx
+++ b/apps/web/src/features/spots/ui/SpotDetail.tsx
@@ -18,7 +18,6 @@ import { useGetSpotById } from '../api';
 import { useShareSpot } from '../model/useShareSpot';
 import { useToggleSpotLike } from '../model/useToggleSpotLike';
 import { SpotMap } from './SpotMap';
-import { StarRating } from './StarRating';
 
 interface SpotDetailProps {
 	spotId: string;
@@ -130,7 +129,7 @@ export function SpotDetail({ spotId }: SpotDetailProps) {
 
 					<div className={styles.meta}>
 						<div className={styles.ratingRow}>
-							<StarRating value={spot.rating} size='md' />
+							{/* <StarRating value={spot.rating} size='md' /> */}
 							<span className={styles.likesCount}>{spot.likes} Likes</span>
 						</div>
 						<Flex justify='space-between'>

--- a/packages/shared/types/category.ts
+++ b/packages/shared/types/category.ts
@@ -1,12 +1,16 @@
-export interface Category {
-	id: string;
-	name: string;
-	type: string;
-	description: string;
-	parent_id: string | null;
-	created_at: string;
-	color: string;
-}
+import { z } from 'zod';
+
+export const CategorySchema = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	type: z.string(),
+	description: z.string(),
+	parent_id: z.string().nullable(),
+	created_at: z.string(),
+	color: z.string(),
+});
+
+export type Category = z.infer<typeof CategorySchema>;
 
 export interface CategoryWithCount extends Category {
 	postCount: number;

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -1,16 +1,5 @@
 import { z } from 'zod';
 
-export const SpotCategorySchema = z.enum([
-	'nature', // 자연/풍경
-	'landmark', // 랜드마크
-	'historic', // 역사/문화유산
-	'culture', // 문화시설
-	'night', // 야경 명소
-	'street', // 거리/골목
-	'park', // 공원
-	'local', // 로컬/전통
-]);
-
 export const SpotSchema = z.object({
 	id: z.string().uuid(),
 	title: z.string(),
@@ -27,20 +16,20 @@ export const SpotSchema = z.object({
 		lat: z.number(),
 		lng: z.number(),
 	}),
-	category: SpotCategorySchema,
+
 	created_at: z.string().datetime(),
 	updated_at: z.string().datetime(),
 	tags: z.string().array().optional(),
 	tips: z.string().array().optional(),
 	likes: z.number(),
 	liked_by: z.array(z.string()),
+	category_id: z.string().uuid(),
 });
 
 export const SpotQueryParamsSchema = z.object({
 	limit: z.number().min(1).max(100).default(10),
 	cursor: z.string().optional(),
-	cat: z.string().optional(),
-	// cat: SpotCategorySchema.optional(),
+	category_id: z.string().uuid().optional(),
 	q: z.string().optional(),
 	sort: z.enum(['latest', 'rating', 'popular', 'oldest']).optional(),
 });
@@ -50,7 +39,8 @@ export const SpotQueryResultSchema = z.object({
 	nextCursor: z.string().nullable(),
 });
 
-export type SpotCategory = z.infer<typeof SpotCategorySchema>;
 export type Spot = z.infer<typeof SpotSchema>;
 export type SpotQueryParams = z.infer<typeof SpotQueryParamsSchema>;
 export type SpotQueryResult = z.infer<typeof SpotQueryResultSchema>;
+
+export type { Category } from './category';

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -11,7 +11,7 @@ export const SpotSchema = z.object({
 			url: z.string().url(),
 		}),
 	),
-	rating: z.number().min(0).max(5),
+	// rating: z.number().min(0).max(5),
 	coordinates: z.object({
 		lat: z.number(),
 		lng: z.number(),

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -32,7 +32,7 @@ export const SpotQueryParamsSchema = z.object({
 	cursor: z.string().optional(),
 	category_id: z.string().uuid().optional(),
 	q: z.string().optional(),
-	sort: z.enum(['latest', 'rating', 'popular', 'oldest']).optional(),
+	sort: z.enum(['latest', 'popular', 'oldest']).optional(),
 });
 
 export const SpotQueryResultSchema = z.object({

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -1,17 +1,18 @@
 import { z } from 'zod';
 
+export const SpotPhotoSchema = z.object({
+	id: z.string().uuid().optional(),
+	url: z.string().url(),
+	status: z.enum(['existing', 'new', 'deleted']),
+});
+
 export const SpotSchema = z.object({
 	id: z.string().uuid(),
 	title: z.string(),
 	description: z.string(),
 	address: z.string(),
-	photos: z.array(
-		z.object({
-			id: z.string(),
-			url: z.string().url(),
-		}),
-	),
-	// rating: z.number().min(0).max(5),
+	photos: z.array(SpotPhotoSchema),
+
 	coordinates: z.object({
 		lat: z.number(),
 		lng: z.number(),
@@ -39,8 +40,14 @@ export const SpotQueryResultSchema = z.object({
 	nextCursor: z.string().nullable(),
 });
 
+export type SpotPhoto = z.infer<typeof SpotPhotoSchema>;
 export type Spot = z.infer<typeof SpotSchema>;
 export type SpotQueryParams = z.infer<typeof SpotQueryParamsSchema>;
 export type SpotQueryResult = z.infer<typeof SpotQueryResultSchema>;
 
 export type { Category } from './category';
+
+export interface SpotImageUpload extends SpotPhoto {
+	file?: File;
+	preview?: string;
+}


### PR DESCRIPTION

## Motivation 🤔

- Need to implement complete spot management functionality including creation, reading, updating and deletion
- Require robust image handling system with error management
- Need to establish consistent API hooks for spot operations

<br>

## Key Changes 🔑

- Added spot API hooks (useGetSpots, useGetCategories) with pagination and filters
- Implemented spot CRUD operations:
  - Create: Added createSpot service with image upload
  - Read: Added getSpotById functionality
  - Update: Implemented spot update with image management
  - Delete: Added deleteSpot service with image cleanup
- Refactored image handling system with:
  - Unified image handling approach
  - SpotImageUpload type for consistent state management
  - Error handling with rollback for failed uploads
- Updated NewSpot component with responsive grid layout
- Implemented error handling for all operations

<br>

## To Reviews 🙏🏻

- Please review the image handling implementation, especially the rollback mechanism
- Check if the API hooks properly handle pagination and filtering
- Verify error handling coverage across all CRUD operations
- Review the responsive layout implementation in NewSpot component
