### PR TITLE
fix: make BlockNote editor read-only in web workspace

### DIFF
--- a/apps/web/src/shared/ui/BlockNote.tsx
+++ b/apps/web/src/shared/ui/BlockNote.tsx
@@ -25,7 +25,12 @@ type Props = {
 const BlockNote = ({ editor }: Props) => {
 	return (
 		<Box borderWidth='hairline' borderColor='gray100' borderRadius='md'>
-			<BlockNoteView editor={editor} formattingToolbar={false} theme='light'>
+			<BlockNoteView
+				editor={editor}
+				editable={false}
+				formattingToolbar={false}
+				theme='light'
+			>
 				<FormattingToolbarController
 					formattingToolbar={() => (
 						<FormattingToolbar>


### PR DESCRIPTION
## Motivation 🤔

- web post editor con not edit content

<br>

## Key Changes 🔑

- Add editable false props to stop modifying content in web page

<br>

## To Reviews 🙏🏻

- Check if web post can not edit content
