### PR TITLE
fix: use ILIKE and replace lowercase for spot category search

### DIFF
--- a/apps/server/services/spot.ts
+++ b/apps/server/services/spot.ts
@@ -34,7 +34,7 @@ export const spotsService = {
 				const { data: categoryIds, error: categoryError } = await supabase
 					.from('categories')
 					.select('id')
-					.eq('name', cat)
+					.ilike('name', cat)
 					.eq('type', 'spots');
 
 				if (categoryError) {

--- a/apps/web/src/features/spot/selectMarker/ui/SelectMarker.tsx
+++ b/apps/web/src/features/spot/selectMarker/ui/SelectMarker.tsx
@@ -69,12 +69,14 @@ export const SelectMarker = ({ spot, clusterer }: SelectMarkerProps) => {
 						)}
 						<div
 							className={styles.customMarker({
-								category: spot.category as SpotCategory,
+								category: spot.category.toLowerCase() as SpotCategory,
 								selected: isSelected,
 							})}
 							onClick={handleClick}
 						>
-							<CategoryIcon category={spot.category as SpotCategory} />
+							<CategoryIcon
+								category={spot.category.toLowerCase() as SpotCategory}
+							/>
 						</div>
 					</div>
 				</OverlayView>


### PR DESCRIPTION
## Motivation 🤔
- Need to improve case-insensitive search for spot categories
- Optimize query performance by using database-level functionality

## Key Changes 🔑
- Replace `spot.category.toLowerCase()` with SQL `ILIKE` operator
- Move case-insensitive matching to database level

## To Reviews 🙏🏻
- Verify case-insensitive search works correctly
- Check if query performance is improved