### PR TITLE
fix: add category property with type for spotDetail page

### DIFF
--- a/apps/server/services/spot.ts
+++ b/apps/server/services/spot.ts
@@ -83,11 +83,12 @@ export const spotsService = {
 			if (!data || data.length === 0) {
 				return {
 					items: [],
-					nextCursor: null,
+					nextCursor: undefined,
 				};
 			}
 
-			const nextCursor = data[data.length - 1]?.id ?? null;
+			const nextCursor =
+				data.length === limit ? data[data.length - 1]?.id : undefined;
 
 			return {
 				items: data.map((spot) => {

--- a/apps/web/src/entities/spot/api/useSpotsQuery.ts
+++ b/apps/web/src/entities/spot/api/useSpotsQuery.ts
@@ -19,7 +19,7 @@ export function useSpotsQuery(params: QueryParams) {
 		},
 		{
 			getNextPageParam: (lastPage) => {
-				if (lastPage.nextCursor === null) {
+				if (!lastPage.items.length || lastPage.items.length < 12) {
 					return undefined;
 				}
 				return lastPage.nextCursor;

--- a/apps/web/src/entities/spot/ui/SpotPhotoGrid.tsx
+++ b/apps/web/src/entities/spot/ui/SpotPhotoGrid.tsx
@@ -1,8 +1,8 @@
 import { BlurImage } from '@/fsd/shared/ui';
 import { Box } from '@jung/design-system/components';
 import type { SpotPhoto } from '@jung/shared/types';
-import * as styles from './SpotPhotoGrid.css';
 import type { GridVariant } from './SpotPhotoGrid.css';
+import * as styles from './SpotPhotoGrid.css';
 
 interface SpotPhotoGridProps {
 	photos: SpotPhoto[];
@@ -19,8 +19,6 @@ export function SpotPhotoGrid({ photos }: SpotPhotoGridProps) {
 	const count = photos.length > 4 ? 4 : photos.length;
 	const variant = GRID_VARIANTS[count];
 
-	console.log(photos, 'photos, spotphotogrid is rendered');
-
 	return (
 		<Box
 			className={`${styles.imageGrid} ${styles.gridVariants({
@@ -29,7 +27,7 @@ export function SpotPhotoGrid({ photos }: SpotPhotoGridProps) {
 		>
 			{photos.slice(0, 4).map((photo, index) => (
 				<Box
-					key={photo.id}
+					key={index}
 					className={`${styles.imageWrapper} ${
 						index === 0 ? styles.mainImage : ''
 					}`}

--- a/apps/web/src/features/spot/selectMarker/ui/SelectMarker.tsx
+++ b/apps/web/src/features/spot/selectMarker/ui/SelectMarker.tsx
@@ -69,13 +69,13 @@ export const SelectMarker = ({ spot, clusterer }: SelectMarkerProps) => {
 						)}
 						<div
 							className={styles.customMarker({
-								category: spot.category.toLowerCase() as SpotCategory,
+								category: spot.category?.toLowerCase() as SpotCategory,
 								selected: isSelected,
 							})}
 							onClick={handleClick}
 						>
 							<CategoryIcon
-								category={spot.category.toLowerCase() as SpotCategory}
+								category={spot.category?.toLowerCase() as SpotCategory}
 							/>
 						</div>
 					</div>

--- a/apps/web/src/views/spots/ui/SpotsPage.tsx
+++ b/apps/web/src/views/spots/ui/SpotsPage.tsx
@@ -48,13 +48,21 @@ function SpotsContent() {
 		hasNextPage,
 	});
 
+	console.log(
+		hasNextPage,
+		isFetchingNextPage,
+		'hasNextPage, isFetchingNextPage',
+	);
+
 	return (
 		<Stack flex='1' marginY='4' width='full'>
 			{isListView ? (
 				<Box>
 					<SpotListWithLikes spots={spots} />
 					<Flex justify='center' align='center' minHeight='10' ref={ref}>
-						{isFetchingNextPage && <LoadingSpinner size='small' />}
+						{isFetchingNextPage && hasNextPage && (
+							<LoadingSpinner size='small' />
+						)}
 					</Flex>
 				</Box>
 			) : (

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -38,7 +38,7 @@ export const SpotQueryParamsSchema = z.object({
 
 export const SpotQueryResultSchema = z.object({
 	items: z.array(SpotSchema),
-	nextCursor: z.string().nullable(),
+	nextCursor: z.string().nullable().optional(),
 });
 
 export type SpotPhoto = z.infer<typeof SpotPhotoSchema>;

--- a/packages/shared/types/spot.ts
+++ b/packages/shared/types/spot.ts
@@ -54,3 +54,10 @@ export interface SpotImageUpload extends SpotPhoto {
 }
 
 export type SpotSort = 'latest' | 'oldest' | 'popular';
+
+export type SpotWithCategory = Spot & {
+	categories: {
+		name: string;
+	};
+	category_id: string;
+};


### PR DESCRIPTION
## Motivation 🤔
- Fix several issues in spots feature including infinite scroll and category display

## Key Changes 🔑
- Add category property with type for spot detail page
- Fix key prop for photo mapping
- Resolve infinite scroll loading issues
- Improve loading spinner visibility conditions

## To Reviews 🙏🏻
- Check infinite scroll behavior
- Verify loading spinner appears correctly
- Confirm spot detail page displays category properly