### PR TITLE
feat: implement consistent user display names across comments and guestbook

### DIFF
--- a/apps/server/lib/getUserDisplayName.ts
+++ b/apps/server/lib/getUserDisplayName.ts
@@ -1,0 +1,17 @@
+import type { User } from '@supabase/supabase-js';
+
+export const getUserDisplayName = (user: User): string => {
+	const provider = user.app_metadata.provider;
+	const metadata = user.user_metadata;
+
+	switch (provider) {
+		case 'github':
+			return metadata.user_name || metadata.name || 'GitHub User';
+		case 'google':
+			return metadata.email?.split('@')[0] || metadata.name || 'Google User';
+		case 'kakao':
+			return metadata.nickname || metadata.name || 'Kakao User';
+		default:
+			return metadata.name || 'User';
+	}
+};

--- a/apps/server/services/comment.ts
+++ b/apps/server/services/comment.ts
@@ -5,6 +5,7 @@ import type {
 	CommentUser,
 } from '@jung/shared/types';
 import { TRPCError } from '@trpc/server';
+import { getUserDisplayName } from '../lib/getUserDisplayName';
 import { supabase } from '../lib/supabase';
 
 import type { PageParams, User } from '@supabase/supabase-js';
@@ -126,7 +127,7 @@ export const CommentService = {
 				acc[user.id] = {
 					id: user.id,
 					email: user.email || '',
-					full_name: user.user_metadata?.full_name || 'Anonymous',
+					full_name: getUserDisplayName(user) || 'Anonymous',
 					avatar_url: user.user_metadata?.avatar_url || null,
 				};
 				return acc;
@@ -205,13 +206,15 @@ export const commentService = {
 			});
 		}
 
+		const userName = getUserDisplayName(userData.user);
+
 		// 댓글과 사용자 정보 결합
 		const commentWithUser: Comment = {
 			...commentData,
 			user: {
 				id: userData.user.id,
 				email: userData.user.email || '',
-				full_name: userData.user.user_metadata?.full_name || 'Anonymous',
+				full_name: userName || 'Anonymous',
 				avatar_url: userData.user.user_metadata?.avatar_url || null,
 			},
 		};
@@ -246,12 +249,14 @@ export const commentService = {
 			});
 		}
 
+		const userName = getUserDisplayName(userData.user);
+
 		const commentWithUser: Comment = {
 			...commentData,
 			user: {
 				id: userData.user.id,
 				email: userData.user.email || '',
-				full_name: userData.user.user_metadata?.full_name || 'Anonymous',
+				full_name: userName || 'Anonymous',
 				avatar_url: userData.user.user_metadata?.avatar_url || null,
 			},
 		};
@@ -341,12 +346,14 @@ export const commentService = {
 			});
 		}
 
+		const userName = getUserDisplayName(userData.user);
+
 		const commentWithUser: Comment = {
 			...commentData,
 			user: {
 				id: userData.user.id,
 				email: userData.user.email || '',
-				full_name: userData.user.user_metadata?.full_name || 'Anonymous',
+				full_name: userName || 'Anonymous',
 				avatar_url: userData.user.user_metadata?.avatar_url || null,
 			},
 		};

--- a/apps/server/services/guestbook.ts
+++ b/apps/server/services/guestbook.ts
@@ -3,6 +3,7 @@ import type {
 	GuestbookQueryResult,
 } from '@jung/shared/types';
 import { TRPCError } from '@trpc/server';
+import { getUserDisplayName } from '../lib/getUserDisplayName';
 import { supabase } from '../lib/supabase';
 
 type QueryParams = {
@@ -115,7 +116,7 @@ export const guestbookService = {
 
 		const user = await this.fetchUserInfo(userId);
 
-		const userName = user.user_metadata?.full_name || user.email;
+		const userName = getUserDisplayName(user);
 		const userAvatar =
 			user.user_metadata?.avatar_url ||
 			`https://api.dicebear.com/7.x/avataaars/svg?seed=${userId}`;


### PR DESCRIPTION
## Motivation 🤔
- Need consistent user display names across the application
- Handle different OAuth providers properly
- Improve user identification in comments and guestbook

## Key Changes 🔑
- Add getUserDisplayName utility function
- Implement provider-specific name extraction (GitHub, Google, Kakao)
- Apply display name logic to comments and guestbook
- Add fallback to 'Anonymous' for missing names

## To Reviews 🙏🏻
- Verify display names appear correctly for different OAuth providers
- Check fallback behavior when user metadata is incomplete
- Confirm consistent naming across comments and guestbook sections