### PR TITLE
feat: Add email notifications for replies and refactor comment mutations with optimistic update

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "react-intersection-observer": "^9.13.1",
     "react-masonry-css": "^1.0.16",
     "react-photo-album": "^3.0.2",
+    "resend": "^4.3.0",
     "server-only": "^0.0.1",
     "zustand": "^4.5.2"
   },

--- a/apps/web/src/features/comment/createComment/api/createCommentAction.ts
+++ b/apps/web/src/features/comment/createComment/api/createCommentAction.ts
@@ -1,6 +1,24 @@
 'use server';
 
 import { caller } from '@/fsd/shared/api/trpc/server';
+import {
+	getApiUrl,
+	getResendApiKey,
+	getResendEmailFrom,
+} from '@/fsd/shared/config';
+import type { CreateReplyInput } from '@jung/shared/types';
+
+import { revalidatePath } from 'next/cache';
+import { Resend } from 'resend';
+import { createReplyAction } from './createReplyAction';
+
+const resendApiKey = getResendApiKey();
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
+if (!resendApiKey) {
+	console.warn(
+		'(createCommentAction) RESEND_API_KEY is not set. Owner notifications will be disabled.',
+	);
+}
 
 export async function createCommentAction(
 	postId: string,
@@ -8,12 +26,60 @@ export async function createCommentAction(
 	userId: string,
 	parentId?: string,
 ) {
-	const newComment = await caller.comment.createComment({
-		postId,
-		content,
-		userId,
-		parentId,
-	});
+	try {
+		if (parentId) {
+			const replyInput: CreateReplyInput = {
+				postId,
+				content,
+				parentCommentId: parentId,
+			};
+			const replyResult = await createReplyAction(replyInput);
+			return replyResult;
+		}
 
-	return newComment;
+		const newComment = await caller.comment.createComment({
+			postId,
+			content,
+			userId,
+		});
+
+		if (resend) {
+			try {
+				await resend.emails.send({
+					from: `JUNG Archive Notification <${getApiUrl()}>`,
+					to: getResendEmailFrom(),
+					subject: `[JUNG Archive] 새 댓글 알림 (Post ID: ${postId})`,
+					html: `
+                        <p>새 댓글이 작성되었습니다.</p>
+                        <ul>
+                            <li><strong>Post ID:</strong> ${postId}</li>
+                            <li><strong>User ID:</strong> ${userId}</li> 
+                            {/* Optionally fetch user email/name here if needed */}
+                        </ul>
+                        <p><strong>내용:</strong></p>
+                        <div style="border-left: 2px solid #ccc; padding-left: 1em; margin: 1em 0;">
+                            ${content}
+                        </div>
+                        <p>
+                            <a href="${getApiUrl()}/blog/${postId}">게시글 보러가기</a>
+                        </p>
+                    `,
+				});
+				console.log('Admin notification email sent for new comment.');
+			} catch (emailError: unknown) {
+				console.error('Failed to send admin notification email:', emailError);
+			}
+		}
+
+		revalidatePath(`/blog/${postId}`);
+
+		return newComment;
+	} catch (error) {
+		console.error('Failed to process comment action:', error);
+
+		if (error instanceof Error) {
+			throw new Error(`댓글 처리 실패: ${error.message}`);
+		}
+		throw new Error('댓글 처리 중 알 수 없는 오류가 발생했습니다.');
+	}
 }

--- a/apps/web/src/features/comment/createComment/api/createReplyAction.ts
+++ b/apps/web/src/features/comment/createComment/api/createReplyAction.ts
@@ -1,0 +1,145 @@
+'use server';
+
+import { getApiUrl } from '@/fsd/shared/config';
+import { TRPCError } from '@trpc/server';
+import { revalidatePath } from 'next/cache';
+import { Resend } from 'resend';
+
+import type { CreateReplyInput } from '@jung/shared/types';
+
+import { createClient } from '@/fsd/shared/api/supabase/server';
+import { caller } from '@/fsd/shared/api/trpc/server';
+import { getResendApiKey } from '@/fsd/shared/config';
+
+const resendApiKey = getResendApiKey();
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
+if (!resendApiKey) {
+	console.warn(
+		'RESEND_API_KEY is not set. Email notifications will be disabled.',
+	);
+}
+
+export async function createReplyAction(input: CreateReplyInput) {
+	const { parentCommentId, postId, content } = input;
+
+	if (!parentCommentId || !postId || !content) {
+		throw new Error('필수 입력값이 누락되었습니다.');
+	}
+
+	const supabase = await createClient();
+
+	try {
+		const {
+			data: { user },
+			error: authError,
+		} = await supabase.auth.getUser();
+
+		if (authError || !user) {
+			console.error('Supabase auth error:', authError);
+			throw new Error('로그인이 필요합니다.');
+		}
+
+		const newReply = await caller.comment.createComment({
+			postId,
+			content,
+			parentId: parentCommentId,
+			userId: user.id,
+		});
+
+		if (resend) {
+			try {
+				const { data: parentCommentData, error: parentCommentError } =
+					await supabase
+						.from('post_comments')
+						.select('user_id')
+						.eq('id', parentCommentId)
+						.single();
+
+				if (parentCommentError) {
+					console.error('Error fetching parent comment:', parentCommentError);
+					throw new Error('원 댓글 정보를 가져오는 데 실패했습니다.');
+				}
+
+				const parentAuthorId = parentCommentData?.user_id;
+
+				if (parentAuthorId && parentAuthorId !== user.id) {
+					const { data: parentAuthor, error: parentAuthorError } =
+						await supabase
+							.from('profiles')
+							.select('email, full_name')
+							.eq('id', parentAuthorId)
+							.single();
+
+					if (parentAuthorError) {
+						console.error(
+							'Error fetching parent author profile:',
+							parentAuthorError,
+						);
+					}
+
+					if (parentAuthor?.email) {
+						await resend.emails.send({
+							from: `JUNG Archive <${getApiUrl()}>`,
+							to: parentAuthor.email,
+							subject: '[JUNG Archive] 회원님의 댓글에 새 답글이 달렸습니다!',
+							html: `
+                                <p>회원님의 댓글에 <strong>${
+																	user.user_metadata?.full_name ||
+																	user.email ||
+																	'누군가'
+																}</strong>님이 새 답글을 남겼습니다:</p>
+                                <div style="border-left: 2px solid #ccc; padding-left: 1em; margin: 1em 0;">
+                                    ${content}
+                                </div>
+                                <p>
+                                    <a href="${getApiUrl()}/blog/${postId}"> 
+                                        답글 확인하러 가기
+                                    </a>
+                                </p>
+                                <hr>
+                                <p style="font-size: 0.8em; color: #777;">
+                                    이 알림은 회원님의 댓글에 답글이 달렸을 때 발송됩니다. 
+                                </p>
+                            `,
+						});
+						console.log(
+							`Reply notification email sent to ${parentAuthor.email}`,
+						);
+					}
+				}
+			} catch (emailError: unknown) {
+				if (emailError instanceof Error) {
+					console.error(
+						'Failed to send reply notification email:',
+						emailError.message,
+					);
+				} else {
+					console.error(
+						'Failed to send reply notification email:',
+						String(emailError),
+					);
+				}
+			}
+		}
+
+		revalidatePath(`/blog/${postId}`);
+
+		return {
+			id: newReply.id,
+			content: newReply.content,
+			created_at: newReply.created_at,
+		};
+	} catch (error: unknown) {
+		console.error('Failed to create reply:', error);
+
+		if (error instanceof TRPCError) {
+			throw new Error(`서버 오류: ${error.message}`);
+		}
+		if (error instanceof Error) {
+			throw new Error(`오류: ${error.message}`);
+		}
+		throw new Error('대댓글 작성 중 알 수 없는 오류가 발생했습니다.');
+	}
+}
+
+export type CreateReplyResult = Awaited<ReturnType<typeof createReplyAction>>;

--- a/apps/web/src/features/comment/createComment/model/useCreateComment.ts
+++ b/apps/web/src/features/comment/createComment/model/useCreateComment.ts
@@ -4,18 +4,14 @@ import { useTRPC } from '@/fsd/app';
 import {
 	COMMENTS_DEFAULT_ORDER,
 	COMMENTS_LIMIT,
+	type CommentData,
 	useSupabaseAuth,
 } from '@/fsd/shared';
 import { useToast } from '@jung/design-system/components';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { createCommentAction } from '../api/createCommentAction';
-import {
-	createOptimisticComment,
-	replaceOptimisticWithReal,
-	rollbackOptimisticUpdate,
-	updateOptimisticComment,
-} from '../lib';
+import { createOptimisticComment, updateOptimisticComment } from '../lib';
 
 export const useCreateComment = () => {
 	const [newComment, setNewComment] = useState('');
@@ -24,33 +20,45 @@ export const useCreateComment = () => {
 	const { user } = useSupabaseAuth();
 	const showToast = useToast();
 
-	const submitComment = async (postId: string, parentId?: string) => {
-		if (!user || !newComment.trim()) return false;
-
-		const isParentTemporary = parentId?.startsWith('temp-');
-		if (isParentTemporary) {
-			showToast(
-				'Please wait while the previous comment is being processed',
-				'warning',
-			);
-			return false;
-		}
-
-		const queryOptions = trpc.comment.getCommentsByPostId.infiniteQueryOptions({
+	const getQueryOptions = (postId: string) =>
+		trpc.comment.getCommentsByPostId.infiniteQueryOptions({
 			postId,
 			order: COMMENTS_DEFAULT_ORDER,
 			limit: COMMENTS_LIMIT,
 		});
 
-		const optimisticComment = createOptimisticComment(
-			newComment,
-			user,
+	const mutation = useMutation({
+		mutationFn: async ({
 			postId,
 			parentId,
-		);
+		}: { postId: string; parentId?: string }) => {
+			if (!user || !newComment.trim()) {
+				throw new Error('User not logged in or comment empty');
+			}
+			const isParentTemporary = parentId?.startsWith('temp-');
+			if (isParentTemporary) {
+				throw new Error(
+					'Please wait while the previous comment is being processed',
+				);
+			}
+			return createCommentAction(postId, newComment, user.id, parentId);
+		},
+		onMutate: async (variables) => {
+			const { postId, parentId } = variables;
+			const queryOptions = getQueryOptions(postId);
 
-		try {
-			await queryClient.ensureInfiniteQueryData(queryOptions);
+			await queryClient.cancelQueries({ queryKey: queryOptions.queryKey });
+
+			const previousData = queryClient.getQueryData<CommentData>(
+				queryOptions.queryKey,
+			);
+
+			const optimisticComment = createOptimisticComment(
+				newComment,
+				user!,
+				postId,
+				parentId,
+			);
 
 			queryClient.setQueryData(queryOptions.queryKey, (oldData) =>
 				updateOptimisticComment(oldData, optimisticComment, parentId),
@@ -58,32 +66,55 @@ export const useCreateComment = () => {
 
 			setNewComment('');
 
-			const serverComment = await createCommentAction(
-				postId,
-				newComment,
-				user.id,
-				parentId,
-			);
-
-			queryClient.setQueryData(queryOptions.queryKey, (oldData) =>
-				replaceOptimisticWithReal(oldData, optimisticComment.id, serverComment),
-			);
-
-			showToast('Comment has been created', 'success');
-			return serverComment;
-		} catch (error) {
-			try {
-				queryClient.setQueryData(queryOptions.queryKey, (oldData) =>
-					rollbackOptimisticUpdate(oldData, optimisticComment.id),
+			return { previousData, optimisticCommentId: optimisticComment.id };
+		},
+		onError: (error, variables, context) => {
+			if (context?.previousData) {
+				queryClient.setQueryData(
+					getQueryOptions(variables.postId).queryKey,
+					context.previousData,
 				);
-			} catch (rollbackError) {
-				queryClient.invalidateQueries(queryOptions);
 			}
 
-			showToast('Failed to create comment', 'error');
-			return false;
+			const message =
+				error instanceof Error ? error.message : 'Failed to create comment';
+			if (
+				message !== 'User not logged in or comment empty' &&
+				message !== 'Please wait while the previous comment is being processed'
+			) {
+				showToast(message, 'error');
+			}
+		},
+		onSuccess: (data, variables, context) => {
+			showToast('Comment has been created', 'success');
+		},
+		onSettled: async (data, error, variables, context) => {
+			await queryClient.invalidateQueries({
+				queryKey: getQueryOptions(variables.postId).queryKey,
+			});
+		},
+	});
+
+	const submitComment = (postId: string, parentId?: string) => {
+		if (!user || !newComment.trim()) {
+			showToast('Please enter a comment and log in.', 'warning');
+			return;
 		}
+		const isParentTemporary = parentId?.startsWith('temp-');
+		if (isParentTemporary) {
+			showToast(
+				'Please wait while the previous comment is being processed',
+				'warning',
+			);
+			return;
+		}
+		mutation.mutate({ postId, parentId });
 	};
 
-	return { newComment, setNewComment, submitComment };
+	return {
+		newComment,
+		setNewComment,
+		submitComment,
+		isPending: mutation.isPending,
+	};
 };

--- a/apps/web/src/features/comment/deleteComment/api/deleteCommentAction.ts
+++ b/apps/web/src/features/comment/deleteComment/api/deleteCommentAction.ts
@@ -1,7 +1,23 @@
 'use server';
 
 import { caller } from '@/fsd/shared/api/trpc/server';
+import { revalidatePath } from 'next/cache';
 
-export async function deleteCommentAction(commentId: string) {
-	await caller.comment.deleteComment({ commentId });
+export async function deleteCommentAction({
+	commentId,
+	postId,
+}: { commentId: string; postId: string }) {
+	try {
+		await caller.comment.deleteComment({ commentId });
+
+		revalidatePath(`/blog/${postId}`);
+
+		return { success: true };
+	} catch (error) {
+		console.error('Failed to delete comment:', error);
+		if (error instanceof Error) {
+			throw new Error(`댓글 삭제 실패: ${error.message}`);
+		}
+		throw new Error('댓글 삭제 중 알 수 없는 오류가 발생했습니다.');
+	}
 }

--- a/apps/web/src/features/comment/deleteComment/model/useDeleteComment.ts
+++ b/apps/web/src/features/comment/deleteComment/model/useDeleteComment.ts
@@ -30,7 +30,7 @@ export const useDeleteComment = () => {
 		}: { commentId: string; postId: string }) => {
 			// Temporary comments only exist client-side
 			if (!commentId.startsWith('temp-')) {
-				await deleteCommentAction(commentId);
+				await deleteCommentAction({ commentId, postId });
 			}
 		},
 		onMutate: async ({ commentId, postId }) => {

--- a/apps/web/src/features/comment/editComment/api/updateCommentAction.ts
+++ b/apps/web/src/features/comment/editComment/api/updateCommentAction.ts
@@ -1,12 +1,27 @@
 'use server';
 
 import { caller } from '@/fsd/shared/api/trpc/server';
+import { revalidatePath } from 'next/cache';
 
-export async function updateCommentAction(commentId: string, content: string) {
-	const updatedComment = await caller.comment.updateComment({
-		id: commentId,
-		content,
-	});
+export async function updateCommentAction({
+	commentId,
+	content,
+	postId,
+}: { commentId: string; content: string; postId: string }) {
+	try {
+		const updatedComment = await caller.comment.updateComment({
+			id: commentId,
+			content,
+		});
 
-	return updatedComment;
+		revalidatePath(`/blog/${postId}`);
+
+		return updatedComment;
+	} catch (error) {
+		console.error('Failed to update comment:', error);
+		if (error instanceof Error) {
+			throw new Error(`댓글 수정 실패: ${error.message}`);
+		}
+		throw new Error('댓글 수정 중 알 수 없는 오류가 발생했습니다.');
+	}
 }

--- a/apps/web/src/features/comment/editComment/ui/EditCommentForm.tsx
+++ b/apps/web/src/features/comment/editComment/ui/EditCommentForm.tsx
@@ -30,13 +30,13 @@ export const EditCommentForm = ({
 	const [content, setContent] = useState(initialContent);
 	const updateComment = useUpdateComment();
 
-	const handleSubmit = async () => {
+	const handleSubmit = () => {
 		if (!content || content.trim() === '') {
 			showToast('Please enter a comment.', 'error');
 			return;
 		}
 
-		await updateComment(commentId, content, postId);
+		updateComment.mutate({ commentId, content, postId });
 		onSuccess?.();
 	};
 

--- a/apps/web/src/features/comment/toggleLikeComment/api/toggleLikeCommentAction.ts
+++ b/apps/web/src/features/comment/toggleLikeComment/api/toggleLikeCommentAction.ts
@@ -1,16 +1,31 @@
 'use server';
 
 import { caller } from '@/fsd/shared/api/trpc/server';
+import { revalidatePath } from 'next/cache';
 
-export async function toggleLikeCommentAction(
-	commentId: string,
-	postId: string,
-	userId: string,
-) {
-	const updatedComment = await caller.comment.toggleLike({
-		commentId,
-		userId: userId,
-	});
+export async function toggleLikeCommentAction({
+	commentId,
+	postId,
+	userId,
+}: {
+	commentId: string;
+	postId: string;
+	userId: string;
+}) {
+	try {
+		const updatedComment = await caller.comment.toggleLike({
+			commentId,
+			userId: userId,
+		});
 
-	return updatedComment;
+		revalidatePath(`/blog/${postId}`);
+
+		return updatedComment;
+	} catch (error) {
+		console.error('Failed to toggle comment like:', error);
+		if (error instanceof Error) {
+			throw new Error(`좋아요 처리 실패: ${error.message}`);
+		}
+		throw new Error('댓글 좋아요 처리 중 알 수 없는 오류가 발생했습니다.');
+	}
 }

--- a/apps/web/src/features/comment/toggleLikeComment/model/useToggleLikeComment.ts
+++ b/apps/web/src/features/comment/toggleLikeComment/model/useToggleLikeComment.ts
@@ -69,11 +69,11 @@ export const useToggleLikeComment = () => {
 			);
 
 			try {
-				const serverComment = await toggleLikeCommentAction(
+				const serverComment = await toggleLikeCommentAction({
 					commentId,
 					postId,
-					user.id,
-				);
+					userId: user.id,
+				});
 				return {
 					serverComment,
 					originalComment,
@@ -102,6 +102,11 @@ export const useToggleLikeComment = () => {
 				showToast(message, 'error');
 			}
 			console.error('Error toggling comment like:', error);
+		},
+		onSettled: async (data, error, variables, context) => {
+			await queryClient.invalidateQueries({
+				queryKey: queryOptions(variables.postId).queryKey,
+			});
 		},
 	});
 

--- a/apps/web/src/shared/config/env.ts
+++ b/apps/web/src/shared/config/env.ts
@@ -49,3 +49,11 @@ export const getGoogleMapsApiKey = (): string => {
 export const getGoogleVerificationCode = (): string => {
 	return process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION_CODE || '';
 };
+
+export const getResendApiKey = (): string => {
+	return process.env.NEXT_PUBLIC_RESEND_API_KEY || '';
+};
+
+export const getResendEmailFrom = (): string => {
+	return process.env.NEXT_PUBLIC_RESEND_EMAIL_FROM || '';
+};

--- a/apps/web/src/widgets/comment/ui/CommentItemRenderer.tsx
+++ b/apps/web/src/widgets/comment/ui/CommentItemRenderer.tsx
@@ -32,7 +32,6 @@ export const CommentItemRenderer = ({
 	const isNested = !!comment.parent_id;
 
 	const isOwner = currentUser?.id === comment.user_id;
-	const isEditable = isOwner && !isNested;
 	const isLiked = currentUser
 		? comment.liked_by.includes(currentUser.id)
 		: false;
@@ -69,7 +68,7 @@ export const CommentItemRenderer = ({
 		>
 			<CommentItem.UserInfo />
 
-			{isEditable ? (
+			{isEditing && isOwner ? (
 				<EditCommentForm
 					commentId={comment.id}
 					initialContent={comment.content}

--- a/apps/web/src/widgets/comment/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment/ui/CommentSection.tsx
@@ -23,17 +23,23 @@ interface CommentSectionProps {
 }
 
 export const CommentSection = ({ postId }: CommentSectionProps) => {
-	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-		useCommentsQuery(postId);
+	const {
+		data: commentsData,
+		fetchNextPage,
+		hasNextPage,
+		isFetchingNextPage,
+		isLoading,
+	} = useCommentsQuery(postId);
 
 	const { data: post } = usePostQuery(postId);
 	const { user: currentUser } = useSupabaseAuth();
 
 	const { ref } = useInfiniteScroll({ hasNextPage, fetchNextPage });
 
-	const commentCount = data?.pages[0]?.totalCount ?? 0;
+	const commentCount = commentsData?.pages[0]?.totalCount ?? 0;
 	const comments =
-		data?.pages.flatMap((page: { items: Comment[] }) => page.items) ?? [];
+		commentsData?.pages.flatMap((page: { items: Comment[] }) => page.items) ??
+		[];
 
 	const renderItem = (comment: Comment) => (
 		<CommentItemRenderer

--- a/packages/shared/types/comment.ts
+++ b/packages/shared/types/comment.ts
@@ -37,3 +37,11 @@ export type CommentQueryResult = {
 
 export type CommentUser = z.infer<typeof CommentUserSchema>;
 export type Comment = z.infer<typeof CommentSchema> & { replies: Comment[] };
+
+export const CreateReplyInputSchema = z.object({
+	parentCommentId: z.string().min(1, 'Need parent comment id.'),
+	postId: z.string().min(1, 'Need post id.'),
+	content: z.string().min(1, 'Need content.'),
+});
+
+export type CreateReplyInput = z.infer<typeof CreateReplyInputSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+        version: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       lint-staged:
         specifier: ^15.2.5
         version: 15.4.3
@@ -54,7 +54,7 @@ importers:
         version: 3.5.3
       turbo:
         specifier: latest
-        version: 2.4.4
+        version: 2.5.0
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.17.23)(@vitest/ui@1.6.1)(jsdom@20.0.3)(terser@5.39.0)
@@ -151,7 +151,7 @@ importers:
         version: 1.112.18(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-plugin':
         specifier: ^1.49.3
-        version: 1.112.18(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))
+        version: 1.112.18(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))(webpack@5.98.0(@swc/core@1.11.21))
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.18
@@ -215,7 +215,7 @@ importers:
         version: 20.17.23
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)
+        version: 10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)
       tsx:
         specifier: ^4.16.2
         version: 4.19.3
@@ -336,6 +336,9 @@ importers:
       react-photo-album:
         specifier: ^3.0.2
         version: 3.0.2(@types/react@18.3.18)(react@18.3.1)
+      resend:
+        specifier: ^4.3.0
+        version: 4.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -366,7 +369,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vanilla-extract/next-plugin':
         specifier: ^2.4.1
-        version: 2.4.10(babel-plugin-macros@3.1.0)(next@14.2.24(@babel/core@7.26.9)(@playwright/test@1.51.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))
+        version: 2.4.10(babel-plugin-macros@3.1.0)(next@14.2.24(@babel/core@7.26.9)(@playwright/test@1.51.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.98.0(@swc/core@1.11.21))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -421,7 +424,7 @@ importers:
         version: 5.0.1(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(terser@5.39.0)(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))
       '@vitejs/plugin-react-swc':
         specifier: latest
-        version: 3.8.1(@swc/helpers@0.5.5)(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))
+        version: 3.9.0(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))
       chromatic:
         specifier: ^11.5.1
         version: 11.27.0
@@ -451,7 +454,7 @@ importers:
         version: 29.7.0
       ts-jest:
         specifier: ^29.1.4
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)))(typescript@5.8.2)
 
   packages/design-system:
     dependencies:
@@ -488,7 +491,7 @@ importers:
         version: 11.2.0(size-limit@11.2.0)
       '@turbo/gen':
         specifier: ^1.13.3
-        version: 1.13.4(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)
+        version: 1.13.4(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)
       '@types/node':
         specifier: ^20.14.1
         version: 20.17.23
@@ -521,7 +524,7 @@ importers:
         version: 11.2.0
       tsup:
         specifier: ^8.1.0
-        version: 8.4.0(@swc/core@1.11.11(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
+        version: 8.4.0(@swc/core@1.11.21)(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0)
       typescript:
         specifier: ^5.7.2
         version: 5.8.2
@@ -1403,6 +1406,13 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@react-email/render@1.0.6':
+    resolution: {integrity: sha512-zNueW5Wn/4jNC1c5LFgXzbUdv5Lhms+FWjOvWAhal7gx5YVf0q6dPJ0dnR70+ifo59gcMLwCZEaTS9EEuUhKvQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@react-google-maps/api@2.20.6':
     resolution: {integrity: sha512-frxkSHWbd36ayyxrEVopSCDSgJUT1tVKXvQld2IyzU3UnDuqqNA3AZE4/fCdqQb2/zBQx3nrWnZB1wBXDcrjcw==}
     peerDependencies:
@@ -1521,6 +1531,9 @@ packages:
     resolution: {integrity: sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==}
     cpu: [x64]
     os: [win32]
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@shikijs/core@1.29.2':
     resolution: {integrity: sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==}
@@ -1772,8 +1785,8 @@ packages:
   '@supabase/supabase-js@2.49.1':
     resolution: {integrity: sha512-lKaptKQB5/juEF5+jzmBeZlz69MdHZuxf+0f50NwhL+IE//m4ZnOeWlsKRjjsM0fVayZiQKqLvYdBn0RLkhGiQ==}
 
-  '@swc/core-darwin-arm64@1.11.11':
-    resolution: {integrity: sha512-vJcjGVDB8cZH7zyOkC0AfpFYI/7GHKG0NSsH3tpuKrmoAXJyCYspKPGid7FT53EAlWreN7+Pew+bukYf5j+Fmg==}
+  '@swc/core-darwin-arm64@1.11.21':
+    resolution: {integrity: sha512-v6gjw9YFWvKulCw3ZA1dY+LGMafYzJksm1mD4UZFZ9b36CyHFowYVYug1ajYRIRqEvvfIhHUNV660zTLoVFR8g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -1784,8 +1797,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.11.11':
-    resolution: {integrity: sha512-/N4dGdqEYvD48mCF3QBSycAbbQd3yoZ2YHSzYesQf8usNc2YpIhYqEH3sql02UsxTjEFOJSf1bxZABDdhbSl6A==}
+  '@swc/core-darwin-x64@1.11.21':
+    resolution: {integrity: sha512-CUiTiqKlzskwswrx9Ve5NhNoab30L1/ScOfQwr1duvNlFvarC8fvQSgdtpw2Zh3MfnfNPpyLZnYg7ah4kbT9JQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -1796,8 +1809,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.11.11':
-    resolution: {integrity: sha512-hsBhKK+wVXdN3x9MrL5GW0yT8o9GxteE5zHAI2HJjRQel3HtW7m5Nvwaq+q8rwMf4YQRd8ydbvwl4iUOZx7i2Q==}
+  '@swc/core-linux-arm-gnueabihf@1.11.21':
+    resolution: {integrity: sha512-YyBTAFM/QPqt1PscD8hDmCLnqPGKmUZpqeE25HXY8OLjl2MUs8+O4KjwPZZ+OGxpdTbwuWFyMoxjcLy80JODvg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
@@ -1808,8 +1821,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.11.11':
-    resolution: {integrity: sha512-YOCdxsqbnn/HMPCNM6nrXUpSndLXMUssGTtzT7ffXqr7WuzRg2e170FVDVQFIkb08E7Ku5uOnnUVAChAJQbMOQ==}
+  '@swc/core-linux-arm64-gnu@1.11.21':
+    resolution: {integrity: sha512-DQD+ooJmwpNsh4acrftdkuwl5LNxxg8U4+C/RJNDd7m5FP9Wo4c0URi5U0a9Vk/6sQNh9aSGcYChDpqCDWEcBw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1820,8 +1833,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.11.11':
-    resolution: {integrity: sha512-nR2tfdQRRzwqR2XYw9NnBk9Fdvff/b8IiJzDL28gRR2QiJWLaE8LsRovtWrzCOYq6o5Uu9cJ3WbabWthLo4jLw==}
+  '@swc/core-linux-arm64-musl@1.11.21':
+    resolution: {integrity: sha512-y1L49+snt1a1gLTYPY641slqy55QotPdtRK9Y6jMi4JBQyZwxC8swWYlQWb+MyILwxA614fi62SCNZNznB3XSA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -1832,8 +1845,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.11.11':
-    resolution: {integrity: sha512-b4gBp5HA9xNWNC5gsYbdzGBJWx4vKSGybGMGOVWWuF+ynx10+0sA/o4XJGuNHm8TEDuNh9YLKf6QkIO8+GPJ1g==}
+  '@swc/core-linux-x64-gnu@1.11.21':
+    resolution: {integrity: sha512-NesdBXv4CvVEaFUlqKj+GA4jJMNUzK2NtKOrUNEtTbXaVyNiXjFCSaDajMTedEB0jTAd9ybB0aBvwhgkJUWkWA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1844,8 +1857,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.11.11':
-    resolution: {integrity: sha512-dEvqmQVswjNvMBwXNb8q5uSvhWrJLdttBSef3s6UC5oDSwOr00t3RQPzyS3n5qmGJ8UMTdPRmsopxmqaODISdg==}
+  '@swc/core-linux-x64-musl@1.11.21':
+    resolution: {integrity: sha512-qFV60pwpKVOdmX67wqQzgtSrUGWX9Cibnp1CXyqZ9Mmt8UyYGvmGu7p6PMbTyX7vdpVUvWVRf8DzrW2//wmVHg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -1856,8 +1869,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.11.11':
-    resolution: {integrity: sha512-aZNZznem9WRnw2FbTqVpnclvl8Q2apOBW2B316gZK+qxbe+ktjOUnYaMhdCG3+BYggyIBDOnaJeQrXbKIMmNdw==}
+  '@swc/core-win32-arm64-msvc@1.11.21':
+    resolution: {integrity: sha512-DJJe9k6gXR/15ZZVLv1SKhXkFst8lYCeZRNHH99SlBodvu4slhh/MKQ6YCixINRhCwliHrpXPym8/5fOq8b7Ig==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -1868,8 +1881,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.11.11':
-    resolution: {integrity: sha512-DjeJn/IfjgOddmJ8IBbWuDK53Fqw7UvOz7kyI/728CSdDYC3LXigzj3ZYs4VvyeOt+ZcQZUB2HA27edOifomGw==}
+  '@swc/core-win32-ia32-msvc@1.11.21':
+    resolution: {integrity: sha512-TqEXuy6wedId7bMwLIr9byds+mKsaXVHctTN88R1UIBPwJA92Pdk0uxDgip0pEFzHB/ugU27g6d8cwUH3h2eIw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -1880,8 +1893,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.11.11':
-    resolution: {integrity: sha512-Gp/SLoeMtsU4n0uRoKDOlGrRC6wCfifq7bqLwSlAG8u8MyJYJCcwjg7ggm0rhLdC2vbiZ+lLVl3kkETp+JUvKg==}
+  '@swc/core-win32-x64-msvc@1.11.21':
+    resolution: {integrity: sha512-BT9BNNbMxdpUM1PPAkYtviaV0A8QcXttjs2MDtOeSqqvSJaPtyM+Fof2/+xSwQDmDEFzbGCcn75M5+xy3lGqpA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -1892,11 +1905,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.11.11':
-    resolution: {integrity: sha512-pCVY2Wn6dV/labNvssk9b3Owi4WOYsapcbWm90XkIj4xH/56Z6gzja9fsU+4MdPuEfC2Smw835nZHcdCFGyX6A==}
+  '@swc/core@1.11.21':
+    resolution: {integrity: sha512-/Y3BJLcwd40pExmdar8MH2UGGvCBrqNN7hauOMckrEX2Ivcbv3IMhrbGX4od1dnF880Ed8y/E9aStZCIQi0EGw==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@swc/helpers': '*'
+      '@swc/helpers': '>=0.5.17'
     peerDependenciesMeta:
       '@swc/helpers':
         optional: true
@@ -1918,6 +1931,9 @@ packages:
 
   '@swc/types@0.1.19':
     resolution: {integrity: sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA==}
+
+  '@swc/types@0.1.21':
+    resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
 
   '@tanstack/history@1.112.18':
     resolution: {integrity: sha512-57QWQ0DWkhJGwUxFqzHD51tfCZmU5Bnl7KY7x3yaKvk/+uU7i0Pz7d4HFTFMl+pxq/Q/zmV8TyQSctM5MIZWvw==}
@@ -2522,8 +2538,8 @@ packages:
     peerDependencies:
       vite: ^4 || ^5 || ^6
 
-  '@vitejs/plugin-react-swc@3.8.1':
-    resolution: {integrity: sha512-aEUPCckHDcFyxpwFm0AIkbtv6PpUp3xTb9wYGFjtABynXjCYKkWoxX0AOK9NT9XCrdk6mBBUOeHQS+RKdcNO1A==}
+  '@vitejs/plugin-react-swc@3.9.0':
+    resolution: {integrity: sha512-jYFUSXhwMCYsh/aQTgSGLIN3Foz5wMbH9ahb0Zva//UzwZYbMiZd7oT3AU9jHT9DLswYDswsRwPU9jVF3yA48Q==}
     peerDependencies:
       vite: ^4 || ^5 || ^6
 
@@ -3345,10 +3361,23 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-case@2.1.1:
     resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
@@ -3547,6 +3576,9 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3865,6 +3897,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
 
@@ -3873,6 +3909,9 @@ packages:
 
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -4404,6 +4443,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -4997,6 +5039,9 @@ packages:
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   pascal-case@2.0.1:
     resolution: {integrity: sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==}
 
@@ -5042,6 +5087,9 @@ packages:
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5350,6 +5398,9 @@ packages:
       '@types/react':
         optional: true
 
+  react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+
   react-redux@7.2.9:
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
@@ -5517,6 +5568,10 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resend@4.3.0:
+    resolution: {integrity: sha512-4OBHeusMVSl0vcba2J3AaGzdZ1SXAAhX/Wkcwobe16AHmlW9h3li8wG62Fhvlsc61e+wlQoxcwJZP6WrBTbghQ==}
+    engines: {node: '>=18'}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -5611,6 +5666,9 @@ packages:
   schema-utils@4.3.0:
     resolution: {integrity: sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==}
     engines: {node: '>= 10.13.0'}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6094,38 +6152,38 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  turbo-darwin-64@2.4.4:
-    resolution: {integrity: sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==}
+  turbo-darwin-64@2.5.0:
+    resolution: {integrity: sha512-fP1hhI9zY8hv0idym3hAaXdPi80TLovmGmgZFocVAykFtOxF+GlfIgM/l4iLAV9ObIO4SUXPVWHeBZQQ+Hpjag==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.4.4:
-    resolution: {integrity: sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==}
+  turbo-darwin-arm64@2.5.0:
+    resolution: {integrity: sha512-p9sYq7kXH7qeJwIQE86cOWv/xNqvow846l6c/qWc26Ib1ci5W7V0sI5thsrP3eH+VA0d+SHalTKg5SQXgNQBWA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.4.4:
-    resolution: {integrity: sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==}
+  turbo-linux-64@2.5.0:
+    resolution: {integrity: sha512-1iEln2GWiF3iPPPS1HQJT6ZCFXynJPd89gs9SkggH2EJsj3eRUSVMmMC8y6d7bBbhBFsiGGazwFIYrI12zs6uQ==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.4.4:
-    resolution: {integrity: sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==}
+  turbo-linux-arm64@2.5.0:
+    resolution: {integrity: sha512-bKBcbvuQHmsX116KcxHJuAcppiiBOfivOObh2O5aXNER6mce7YDDQJy00xQQNp1DhEfcSV2uOsvb3O3nN2cbcA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.4.4:
-    resolution: {integrity: sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==}
+  turbo-windows-64@2.5.0:
+    resolution: {integrity: sha512-9BCo8oQ7BO7J0K913Czbc3tw8QwLqn2nTe4E47k6aVYkM12ASTScweXPTuaPFP5iYXAT6z5Dsniw704Ixa5eGg==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.4.4:
-    resolution: {integrity: sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==}
+  turbo-windows-arm64@2.5.0:
+    resolution: {integrity: sha512-OUHCV+ueXa3UzfZ4co/ueIHgeq9B2K48pZwIxKSm5VaLVuv8M13MhM7unukW09g++dpdrrE1w4IOVgxKZ0/exg==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.4.4:
-    resolution: {integrity: sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==}
+  turbo@2.5.0:
+    resolution: {integrity: sha512-PvSRruOsitjy6qdqwIIyolv99+fEn57gP6gn4zhsHTEcCYgXPhv6BAxzAjleS8XKpo+Y582vTTA9nuqYDmbRuA==}
     hasBin: true
 
   type-detect@4.0.8:
@@ -7263,7 +7321,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -7277,7 +7335,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7298,7 +7356,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -7312,7 +7370,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7579,6 +7637,14 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@react-email/render@1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.5.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-promise-suspense: 0.3.4
+
   '@react-google-maps/api@2.20.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@googlemaps/js-api-loader': 1.16.8
@@ -7660,6 +7726,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.34.9':
     optional: true
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@shikijs/core@1.29.2':
     dependencies:
@@ -7997,82 +8068,81 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@swc/core-darwin-arm64@1.11.11':
+  '@swc/core-darwin-arm64@1.11.21':
     optional: true
 
   '@swc/core-darwin-arm64@1.11.7':
     optional: true
 
-  '@swc/core-darwin-x64@1.11.11':
+  '@swc/core-darwin-x64@1.11.21':
     optional: true
 
   '@swc/core-darwin-x64@1.11.7':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.11.11':
+  '@swc/core-linux-arm-gnueabihf@1.11.21':
     optional: true
 
   '@swc/core-linux-arm-gnueabihf@1.11.7':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.11.11':
+  '@swc/core-linux-arm64-gnu@1.11.21':
     optional: true
 
   '@swc/core-linux-arm64-gnu@1.11.7':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.11.11':
+  '@swc/core-linux-arm64-musl@1.11.21':
     optional: true
 
   '@swc/core-linux-arm64-musl@1.11.7':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.11.11':
+  '@swc/core-linux-x64-gnu@1.11.21':
     optional: true
 
   '@swc/core-linux-x64-gnu@1.11.7':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.11.11':
+  '@swc/core-linux-x64-musl@1.11.21':
     optional: true
 
   '@swc/core-linux-x64-musl@1.11.7':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.11.11':
+  '@swc/core-win32-arm64-msvc@1.11.21':
     optional: true
 
   '@swc/core-win32-arm64-msvc@1.11.7':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.11.11':
+  '@swc/core-win32-ia32-msvc@1.11.21':
     optional: true
 
   '@swc/core-win32-ia32-msvc@1.11.7':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.11.11':
+  '@swc/core-win32-x64-msvc@1.11.21':
     optional: true
 
   '@swc/core-win32-x64-msvc@1.11.7':
     optional: true
 
-  '@swc/core@1.11.11(@swc/helpers@0.5.5)':
+  '@swc/core@1.11.21':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.19
+      '@swc/types': 0.1.21
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.11.11
-      '@swc/core-darwin-x64': 1.11.11
-      '@swc/core-linux-arm-gnueabihf': 1.11.11
-      '@swc/core-linux-arm64-gnu': 1.11.11
-      '@swc/core-linux-arm64-musl': 1.11.11
-      '@swc/core-linux-x64-gnu': 1.11.11
-      '@swc/core-linux-x64-musl': 1.11.11
-      '@swc/core-win32-arm64-msvc': 1.11.11
-      '@swc/core-win32-ia32-msvc': 1.11.11
-      '@swc/core-win32-x64-msvc': 1.11.11
-      '@swc/helpers': 0.5.5
+      '@swc/core-darwin-arm64': 1.11.21
+      '@swc/core-darwin-x64': 1.11.21
+      '@swc/core-linux-arm-gnueabihf': 1.11.21
+      '@swc/core-linux-arm64-gnu': 1.11.21
+      '@swc/core-linux-arm64-musl': 1.11.21
+      '@swc/core-linux-x64-gnu': 1.11.21
+      '@swc/core-linux-x64-musl': 1.11.21
+      '@swc/core-win32-arm64-msvc': 1.11.21
+      '@swc/core-win32-ia32-msvc': 1.11.21
+      '@swc/core-win32-x64-msvc': 1.11.21
 
   '@swc/core@1.11.7(@swc/helpers@0.5.5)':
     dependencies:
@@ -8099,6 +8169,10 @@ snapshots:
       tslib: 2.8.1
 
   '@swc/types@0.1.19':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@swc/types@0.1.21':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -8167,7 +8241,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@tanstack/router-plugin@1.112.18(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))':
+  '@tanstack/router-plugin@1.112.18(@tanstack/react-router@1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))(webpack@5.98.0(@swc/core@1.11.21))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
@@ -8189,7 +8263,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.112.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite: 5.4.14(@types/node@20.17.24)(terser@5.39.0)
-      webpack: 5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5))
+      webpack: 5.98.0(@swc/core@1.11.21)
     transitivePeerDependencies:
       - supports-color
 
@@ -8442,7 +8516,7 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen@1.13.4(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)':
+  '@turbo/gen@1.13.4(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)':
     dependencies:
       '@turbo/workspaces': 1.13.4
       chalk: 2.4.2
@@ -8452,7 +8526,7 @@ snapshots:
       minimatch: 9.0.5
       node-plop: 0.26.3
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -8772,9 +8846,9 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  '@vanilla-extract/next-plugin@2.4.10(babel-plugin-macros@3.1.0)(next@14.2.24(@babel/core@7.26.9)(@playwright/test@1.51.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))':
+  '@vanilla-extract/next-plugin@2.4.10(babel-plugin-macros@3.1.0)(next@14.2.24(@babel/core@7.26.9)(@playwright/test@1.51.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.98.0(@swc/core@1.11.21))':
     dependencies:
-      '@vanilla-extract/webpack-plugin': 2.3.18(babel-plugin-macros@3.1.0)(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))
+      '@vanilla-extract/webpack-plugin': 2.3.18(babel-plugin-macros@3.1.0)(webpack@5.98.0(@swc/core@1.11.21))
       next: 14.2.24(@babel/core@7.26.9)(@playwright/test@1.51.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -8825,13 +8899,13 @@ snapshots:
       - supports-color
       - terser
 
-  '@vanilla-extract/webpack-plugin@2.3.18(babel-plugin-macros@3.1.0)(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))':
+  '@vanilla-extract/webpack-plugin@2.3.18(babel-plugin-macros@3.1.0)(webpack@5.98.0(@swc/core@1.11.21))':
     dependencies:
       '@vanilla-extract/integration': 8.0.1(babel-plugin-macros@3.1.0)
       debug: 4.4.0
       loader-utils: 2.0.4
       picocolors: 1.1.1
-      webpack: 5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5))
+      webpack: 5.98.0(@swc/core@1.11.21)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8843,9 +8917,9 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@3.8.1(@swc/helpers@0.5.5)(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))':
+  '@vitejs/plugin-react-swc@3.9.0(vite@5.4.14(@types/node@20.17.24)(terser@5.39.0))':
     dependencies:
-      '@swc/core': 1.11.11(@swc/helpers@0.5.5)
+      '@swc/core': 1.11.21
       vite: 5.4.14(@types/node@20.17.24)(terser@5.39.0)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -8919,7 +8993,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@types/node@20.17.24)(@vitest/ui@1.6.1)(jsdom@20.0.3)(terser@5.39.0)
+      vitest: 1.6.1(@types/node@20.17.23)(@vitest/ui@1.6.1)(jsdom@20.0.3)(terser@5.39.0)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -9508,13 +9582,13 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  create-jest@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9523,13 +9597,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)):
+  create-jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9752,9 +9826,27 @@ snapshots:
       '@babel/runtime': 7.26.9
       csstype: 3.1.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-case@2.1.1:
     dependencies:
@@ -9994,6 +10086,8 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -10421,11 +10515,26 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-void-elements@2.0.1: {}
 
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -10800,16 +10909,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10819,16 +10928,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)):
+  jest-cli@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      create-jest: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      jest-config: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10838,7 +10947,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -10864,12 +10973,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.23
-      ts-node: 10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -10895,12 +11004,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.23
-      ts-node: 10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)):
+  jest-config@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)):
     dependencies:
       '@babel/core': 7.26.9
       '@jest/test-sequencer': 29.7.0
@@ -10926,7 +11035,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.17.24
-      ts-node: 10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11167,24 +11276,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@20.17.23)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)):
+  jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      jest-cli: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11264,6 +11373,8 @@ snapshots:
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  leac@0.6.0: {}
 
   leven@3.1.0: {}
 
@@ -12062,6 +12173,11 @@ snapshots:
     dependencies:
       entities: 4.5.0
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   pascal-case@2.0.1:
     dependencies:
       camel-case: 3.0.0
@@ -12095,6 +12211,8 @@ snapshots:
   pathval@1.1.1: {}
 
   pathval@2.0.0: {}
+
+  peberminta@0.9.0: {}
 
   picocolors@1.1.1: {}
 
@@ -12419,6 +12537,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
+  react-promise-suspense@0.3.4:
+    dependencies:
+      fast-deep-equal: 2.0.1
+
   react-redux@7.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.26.9
@@ -12642,6 +12764,13 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resend@4.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@react-email/render': 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -12749,6 +12878,10 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver@6.3.1: {}
 
@@ -13047,16 +13180,16 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.11(@swc/helpers@0.5.5))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5))):
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.21)(webpack@5.98.0(@swc/core@1.11.21)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5))
+      webpack: 5.98.0(@swc/core@1.11.21)
     optionalDependencies:
-      '@swc/core': 1.11.11(@swc/helpers@0.5.5)
+      '@swc/core': 1.11.21
 
   terser@5.39.0:
     dependencies:
@@ -13159,12 +13292,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2))
+      jest: 29.7.0(@types/node@20.17.24)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -13178,7 +13311,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.9)
 
-  ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.23)(typescript@5.8.2):
+  ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.23)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13196,9 +13329,9 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.11.11(@swc/helpers@0.5.5)
+      '@swc/core': 1.11.21
 
-  ts-node@10.9.2(@swc/core@1.11.11(@swc/helpers@0.5.5))(@types/node@20.17.24)(typescript@5.8.2):
+  ts-node@10.9.2(@swc/core@1.11.21)(@types/node@20.17.24)(typescript@5.8.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13216,7 +13349,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.11.11(@swc/helpers@0.5.5)
+      '@swc/core': 1.11.21
     optional: true
 
   tsconfig-paths@4.2.0:
@@ -13229,7 +13362,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(@swc/core@1.11.11(@swc/helpers@0.5.5))(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0):
+  tsup@8.4.0(@swc/core@1.11.21)(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
       cac: 6.7.14
@@ -13248,7 +13381,7 @@ snapshots:
       tinyglobby: 0.2.12
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.11.11(@swc/helpers@0.5.5)
+      '@swc/core': 1.11.21
       postcss: 8.5.3
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -13264,32 +13397,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo-darwin-64@2.4.4:
+  turbo-darwin-64@2.5.0:
     optional: true
 
-  turbo-darwin-arm64@2.4.4:
+  turbo-darwin-arm64@2.5.0:
     optional: true
 
-  turbo-linux-64@2.4.4:
+  turbo-linux-64@2.5.0:
     optional: true
 
-  turbo-linux-arm64@2.4.4:
+  turbo-linux-arm64@2.5.0:
     optional: true
 
-  turbo-windows-64@2.4.4:
+  turbo-windows-64@2.5.0:
     optional: true
 
-  turbo-windows-arm64@2.4.4:
+  turbo-windows-arm64@2.5.0:
     optional: true
 
-  turbo@2.4.4:
+  turbo@2.5.0:
     optionalDependencies:
-      turbo-darwin-64: 2.4.4
-      turbo-darwin-arm64: 2.4.4
-      turbo-linux-64: 2.4.4
-      turbo-linux-arm64: 2.4.4
-      turbo-windows-64: 2.4.4
-      turbo-windows-arm64: 2.4.4
+      turbo-darwin-64: 2.5.0
+      turbo-darwin-arm64: 2.5.0
+      turbo-linux-64: 2.5.0
+      turbo-linux-arm64: 2.5.0
+      turbo-windows-64: 2.5.0
+      turbo-windows-arm64: 2.5.0
 
   type-detect@4.0.8: {}
 
@@ -13728,7 +13861,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)):
+  webpack@5.98.0(@swc/core@1.11.21):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -13750,7 +13883,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.11(@swc/helpers@0.5.5))(webpack@5.98.0(@swc/core@1.11.11(@swc/helpers@0.5.5)))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.21)(webpack@5.98.0(@swc/core@1.11.21))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Motivation 🤔

- Introduce transactional email feature using `resend` for future reply notifications
- Improve comment-related UX with optimistic UI updates and better error handling
- Clean up and type-safe the comment component structure for clarity and maintainability

<br>

## Key Changes 🔑

- Added `resend` package and setup API key/env utilities
- Reworked all comment mutation hooks (`create`, `edit`, `delete`, `like`) to use `useMutation`
- Implemented optimistic update and rollback logic
- Improved error boundaries and toast notifications
- Refactored comment UI state logic (`isEditing`, `isOwner`)
- Introduced Zod schema (`CreateReplyInputSchema`) for reply validation

<br>

## To Reviews 🙏🏻

- Check if the optimistic update behaves as expected when editing/liking comments
- Ensure resend integration is ready for later `reply-to-comment` email trigger
- Review refactored component logic and types for clarity
