### PR TITLE
fix(post): Improve post like toggling & editor loading state handling

### DIFF
--- a/apps/web/src/entities/comment/ui/CommentStats.tsx
+++ b/apps/web/src/entities/comment/ui/CommentStats.tsx
@@ -1,27 +1,11 @@
-import { Flex, Typography } from '@jung/design-system/components';
-import { FaRegComment, FaRegHeart } from 'react-icons/fa';
+import { Typography } from '@jung/design-system/components';
 
 interface CommentStatsProps {
 	commentCount: number;
-	likeCount: number;
 }
 
-export const CommentStats = ({
-	commentCount,
-	likeCount,
-}: CommentStatsProps) => (
-	<Flex columnGap='4' alignItems='center' marginBottom='4'>
-		<Flex alignItems='center' columnGap='1'>
-			<FaRegComment size={18} color='#0142C0' />
-			<Typography.SubText level={2} color='primary'>
-				{commentCount}
-			</Typography.SubText>
-		</Flex>
-		<Flex alignItems='center' columnGap='1'>
-			<FaRegHeart size={18} color='#0142C0' />
-			<Typography.SubText level={2} color='primary'>
-				{likeCount}
-			</Typography.SubText>
-		</Flex>
-	</Flex>
+export const CommentStats = ({ commentCount }: CommentStatsProps) => (
+	<Typography.Text level={2} color='primary'>
+		{commentCount} {commentCount > 1 ? 'Comments' : 'Comment'}
+	</Typography.Text>
 );

--- a/apps/web/src/features/post/togglePostLike/api/togglePostLikeAction.ts
+++ b/apps/web/src/features/post/togglePostLike/api/togglePostLikeAction.ts
@@ -8,7 +8,11 @@ export async function togglePostLikeAction(postId: string, userId: string) {
 		postId,
 		userId: userId,
 	});
-
-	revalidatePath(`/blog/${postId}`);
-	return updatedPost;
+	try {
+		revalidatePath(`/blog/${postId}`);
+		return updatedPost;
+	} catch (error) {
+		console.error('Failed to toggle post like:', error);
+		throw new Error('Failed to toggle post like');
+	}
 }

--- a/apps/web/src/features/post/togglePostLike/model/useTogglePostLike.ts
+++ b/apps/web/src/features/post/togglePostLike/model/useTogglePostLike.ts
@@ -1,7 +1,8 @@
 import { useTRPC } from '@/fsd/app';
 import { useSupabaseAuth } from '@/fsd/shared';
 import { useToast } from '@jung/design-system/components';
-import { useQueryClient } from '@tanstack/react-query';
+import type { Post } from '@jung/shared/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { togglePostLikeAction } from '../api/togglePostLikeAction';
 import { updatePostLikes } from './../lib/updatePostLikes';
 
@@ -11,37 +12,61 @@ export const useTogglePostLike = () => {
 	const { user } = useSupabaseAuth();
 	const showToast = useToast();
 
-	const toggleLike = async (postId: string) => {
-		if (!user) {
-			showToast('Please log in to like posts', 'error');
-			return;
-		}
+	const mutation = useMutation({
+		mutationFn: async (postId: string) => {
+			if (!user) {
+				throw new Error('Please log in to like posts');
+			}
 
-		const previousData = queryClient.getQueryData(
-			trpc.post.getPostById.queryOptions({ postId }).queryKey,
-		);
-
-		const isLiked = previousData?.liked_by.includes(user.id);
-
-		// Optimistic update
-		queryClient.setQueryData(
-			trpc.post.getPostById.queryOptions({ postId }).queryKey,
-			(old) => updatePostLikes(old, postId, isLiked ? -1 : 1, user.id),
-		);
-
-		try {
 			await togglePostLikeAction(postId, user.id);
-		} catch (error) {
-			queryClient.setQueryData(
+			return { postId };
+		},
+		onMutate: async (postId: string) => {
+			if (!user) {
+				showToast('Please log in to like posts', 'error');
+
+				throw new Error('Please log in to like posts');
+			}
+			await queryClient.cancelQueries({
+				queryKey: trpc.post.getPostById.queryOptions({ postId }).queryKey,
+			});
+
+			const previousData = queryClient.getQueryData<Post>(
 				trpc.post.getPostById.queryOptions({ postId }).queryKey,
-				previousData,
 			);
 
-			if (error instanceof Error) {
+			if (previousData) {
+				const isLiked = previousData.liked_by.includes(user.id);
+				queryClient.setQueryData(
+					trpc.post.getPostById.queryOptions({ postId }).queryKey,
+					(old) => updatePostLikes(old, postId, isLiked ? -1 : 1, user.id),
+				);
+			}
+
+			return { previousData, postId };
+		},
+		onError: (error: Error, postId, context) => {
+			if (context?.previousData) {
+				queryClient.setQueryData(
+					trpc.post.getPostById.queryOptions({ postId }).queryKey,
+					context.previousData,
+				);
+			}
+			if (error.message !== 'Please log in to like posts') {
 				showToast(`Failed to update like: ${error.message}`, 'error');
 			}
-		}
-	};
+			console.error('Error toggling post like:', error);
+		},
+		onSettled: (data, error, postId, context) => {
+			queryClient.invalidateQueries({
+				queryKey: trpc.post.getPostById.queryOptions({ postId: postId })
+					.queryKey,
+			});
+		},
+	});
 
-	return toggleLike;
+	return {
+		toggleLike: mutation.mutate,
+		isPending: mutation.isPending,
+	};
 };

--- a/apps/web/src/features/post/togglePostLike/ui/TogglePostLike.tsx
+++ b/apps/web/src/features/post/togglePostLike/ui/TogglePostLike.tsx
@@ -16,7 +16,7 @@ export const TogglePostLike = ({ likeCount, postId, likedBy }: Props) => {
 	const { user } = useSupabaseAuth();
 	const showToast = useToast();
 
-	const toggleLike = useTogglePostLike();
+	const { toggleLike } = useTogglePostLike();
 
 	const handleLikeClick = () => {
 		if (!user) {
@@ -44,18 +44,19 @@ export const TogglePostLike = ({ likeCount, postId, likedBy }: Props) => {
 				fontSize='sm'
 				borderRadius='md'
 				prefix={isLiked ? <FaHeart size={16} /> : <FaRegHeart size={16} />}
+				// loading={isPending}
 			>
-				{isLiked ? 'Liked' : 'Like'}
+				{likeCount} {likeCount > 1 ? 'Likes' : 'Like'}
 			</Button>
 
 			<Link href='/guestbook'>
 				<Button
-					variant='secondary'
+					variant='primary'
 					borderRadius='md'
 					prefix={<BsPencilSquare size={16} />}
 					fontSize='sm'
 				>
-					Visit Guestbook
+					Guestbook
 				</Button>
 			</Link>
 		</Flex>

--- a/apps/web/src/views/blog/ui/PostDetailContent.tsx
+++ b/apps/web/src/views/blog/ui/PostDetailContent.tsx
@@ -4,13 +4,14 @@ import { TogglePostLike } from '@/fsd/features/post';
 
 import { usePostQuery } from '@/fsd/entities/post';
 
+import { EditorSkeleton } from '@/fsd/shared/ui/EditorSkeleton';
 import dynamic from 'next/dynamic';
 
 const BlockNoteEditor = dynamic(
 	() => import('@/fsd/shared/ui/BlockNote').then((mod) => mod.BlockNote),
 	{
 		ssr: false,
-		// loading: () => <EditorSkeleton />,
+		loading: () => <EditorSkeleton />,
 	},
 );
 

--- a/apps/web/src/widgets/comment/ui/CommentSection.tsx
+++ b/apps/web/src/widgets/comment/ui/CommentSection.tsx
@@ -56,7 +56,7 @@ export const CommentSection = ({ postId }: CommentSectionProps) => {
 
 	return (
 		<>
-			<CommentStats commentCount={commentCount} likeCount={post?.likes ?? 0} />
+			<CommentStats commentCount={commentCount} />
 			<CreateCommentForm postId={postId} postTitle={post?.title || ''} />
 
 			{isLoading ? (


### PR DESCRIPTION
## Motivation 🤔

- Improve UX and stability by handling errors more gracefully during post like toggling.
- Enhance loading experience in post editor with a fallback skeleton UI.
- Simplify comment stats display logic by removing redundant like count state.

<br>

## Key Changes 🔑

- Refactored `useTogglePostLike` hook and `togglePostLikeAction` with better error handling.
- Applied `EditorSkeleton` component to show loading state for `BlockNoteEditor`.
- Removed `likeCount` state from `CommentStats` and updated its display logic.

<br>

## To Reviews 🙏🏻

- Check if like toggling works reliably with proper loading/error feedback.
- Verify that the post editor shows the skeleton during initial load.
- Ensure that `CommentStats` reflects UI updates correctly without the local like count state.
