### PR TITLE
fix: resolve post-merge type errors across monorepo

### DIFF
--- a/apps/admin/src/features/articles/model/useArticleTable.ts
+++ b/apps/admin/src/features/articles/model/useArticleTable.ts
@@ -29,7 +29,7 @@ export const articleColumns: ColumnDef<Article>[] = [
 const PAGE_SIZE = 10;
 
 export const useArticleTable = () => {
-	const navigate = useNavigate({ from: '/articles' });
+	const navigate = useNavigate({ from: '/articles/' });
 	const searchParams = useSearch({ from: '/articles/' }) as ArticleFilters;
 	const queryClient = useQueryClient();
 

--- a/apps/admin/src/features/articles/model/useArticleTableFilter.ts
+++ b/apps/admin/src/features/articles/model/useArticleTableFilter.ts
@@ -5,7 +5,7 @@ import type { ArticleFilters } from '../types';
 
 export const useArticleTableFilter = () => {
 	const searchParams: ArticleFilters = useSearch({ from: '/articles/' });
-	const navigate = useNavigate({ from: '/articles' });
+	const navigate = useNavigate({ from: '/articles/' });
 
 	const [filter, setFilter] = useState(searchParams.filter ?? '');
 

--- a/apps/admin/src/features/articles/ui/ArticleTable/TableContent.tsx
+++ b/apps/admin/src/features/articles/ui/ArticleTable/TableContent.tsx
@@ -97,11 +97,7 @@ export const TableContent = ({
 						isIndeterminate={bulk.isIndeterminate(allIds)}
 						onToggleAll={() => bulk.toggleAll(allIds)}
 					/>
-					<TableBody
-						table={table}
-						isSelected={bulk.isSelected}
-						onToggle={bulk.toggle}
-					/>
+					<TableBody table={table} />
 				</Box>
 			</Box>
 			<TablePagination table={table} />

--- a/apps/admin/src/features/blog/model/usePostTable.ts
+++ b/apps/admin/src/features/blog/model/usePostTable.ts
@@ -32,7 +32,7 @@ export const postColumns: ColumnDef<AdminPost>[] = [
 const PAGE_SIZE = 10;
 
 export const usePostTable = () => {
-	const navigate = useNavigate({ from: '/blog' });
+	const navigate = useNavigate({ from: '/blog/' });
 	const searchParams = useSearch({ from: '/blog/' }) as PostFilters;
 	const queryClient = useQueryClient();
 

--- a/apps/admin/src/features/blog/model/usePostTableFilter.ts
+++ b/apps/admin/src/features/blog/model/usePostTableFilter.ts
@@ -5,7 +5,7 @@ import type { PostFilters } from '@/fsd/features';
 
 export const usePostTableFilter = () => {
 	const searchParams: PostFilters = useSearch({ from: '/blog/' });
-	const navigate = useNavigate({ from: '/blog' });
+	const navigate = useNavigate({ from: '/blog/' });
 
 	const [filter, setFilter] = useState(searchParams.filter ?? '');
 

--- a/apps/admin/src/features/gallery/model/usePhotoTable.ts
+++ b/apps/admin/src/features/gallery/model/usePhotoTable.ts
@@ -38,7 +38,7 @@ export const photoColumns: ColumnDef<Photo>[] = [
 const PAGE_SIZE = 10;
 
 export const usePhotoTable = () => {
-	const navigate = useNavigate({ from: '/gallery/photos' });
+	const navigate = useNavigate({ from: '/gallery/photos/' });
 	const searchParams = useSearch({ from: '/gallery/photos/' }) as PhotoFilters;
 	const queryClient = useQueryClient();
 

--- a/apps/admin/src/features/gallery/model/usePhotoTableFilter.ts
+++ b/apps/admin/src/features/gallery/model/usePhotoTableFilter.ts
@@ -5,7 +5,7 @@ import type { PhotoFilters } from './usePhotoTable';
 
 export const usePhotoTableFilter = () => {
 	const searchParams: PhotoFilters = useSearch({ from: '/gallery/photos/' });
-	const navigate = useNavigate({ from: '/gallery/photos' });
+	const navigate = useNavigate({ from: '/gallery/photos/' });
 
 	const [filter, setFilter] = useState(searchParams.filter ?? '');
 

--- a/apps/admin/src/features/places/model/usePlaceTable.ts
+++ b/apps/admin/src/features/places/model/usePlaceTable.ts
@@ -20,7 +20,7 @@ import { fetchPlaces } from '../services/getPlaces';
 const PAGE_SIZE = 10;
 
 export const usePlaceTable = () => {
-	const navigate = useNavigate({ from: '/places' });
+	const navigate = useNavigate({ from: '/places/' });
 	const searchParams = useSearch({ from: '/places/' }) as PlaceFilters;
 	const queryClient = useQueryClient();
 

--- a/apps/admin/src/features/places/model/usePlaceTableFilter.ts
+++ b/apps/admin/src/features/places/model/usePlaceTableFilter.ts
@@ -5,7 +5,7 @@ import type { PlaceFilters } from '../services/getPlaces';
 
 export const usePlaceTableFilter = () => {
 	const searchParams: PlaceFilters = useSearch({ from: '/places/' });
-	const navigate = useNavigate({ from: '/places' });
+	const navigate = useNavigate({ from: '/places/' });
 
 	const [filter, setFilter] = useState(searchParams.filter ?? '');
 

--- a/apps/admin/src/features/subscribers/ui/SubscriberStats.tsx
+++ b/apps/admin/src/features/subscribers/ui/SubscriberStats.tsx
@@ -37,9 +37,21 @@ const SubscriberStats = () => {
 			<StatCard label='Total' value={stats.total} />
 			<StatCard label='Active' value={stats.active} color='#059669' />
 			<StatCard label='Inactive' value={stats.inactive} color='#DC2626' />
-			<StatCard label='Frontend' value={stats.frontend} color='#0142C0' />
-			<StatCard label='AI' value={stats.ai} color='#9333EA' />
-			<StatCard label='Both' value={stats.both} color='#D97706' />
+			<StatCard
+				label='Frontend'
+				value={stats.categoryDistribution.frontend}
+				color='#0142C0'
+			/>
+			<StatCard
+				label='AI'
+				value={stats.categoryDistribution.ai}
+				color='#9333EA'
+			/>
+			<StatCard
+				label='Both'
+				value={stats.categoryDistribution.both}
+				color='#D97706'
+			/>
 		</Flex>
 	);
 };

--- a/apps/admin/src/features/subscribers/ui/SubscriberTable/useSubscriberTableFilter.ts
+++ b/apps/admin/src/features/subscribers/ui/SubscriberTable/useSubscriberTableFilter.ts
@@ -7,7 +7,7 @@ export const useSubscriberTableFilter = () => {
 	const searchParams: SubscriberFilters = useSearch({
 		from: '/subscribers/',
 	});
-	const navigate = useNavigate({ from: '/subscribers' });
+	const navigate = useNavigate({ from: '/subscribers/' });
 
 	const [filter, setFilter] = useState(searchParams.filter ?? '');
 

--- a/apps/admin/src/routes/articles/index.tsx
+++ b/apps/admin/src/routes/articles/index.tsx
@@ -1,6 +1,33 @@
 import { createFileRoute } from '@tanstack/react-router';
 import ArticlesPage from '@/fsd/views/articles/ui/ArticlesPage';
 
+interface ArticleSearchParams {
+	page?: number;
+	pageSize?: number;
+	sortField?: string;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+	category?: string;
+	status?: string;
+}
+
 export const Route = createFileRoute('/articles/')({
 	component: ArticlesPage,
+	validateSearch: (search: Record<string, unknown>): ArticleSearchParams => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			pageSize:
+				typeof search.pageSize === 'number' ? search.pageSize : undefined,
+			sortField:
+				typeof search.sortField === 'string' ? search.sortField : undefined,
+			sortOrder:
+				search.sortOrder === 'asc' || search.sortOrder === 'desc'
+					? search.sortOrder
+					: undefined,
+			filter: typeof search.filter === 'string' ? search.filter : undefined,
+			category:
+				typeof search.category === 'string' ? search.category : undefined,
+			status: typeof search.status === 'string' ? search.status : undefined,
+		};
+	},
 });

--- a/apps/admin/src/routes/blog/index.tsx
+++ b/apps/admin/src/routes/blog/index.tsx
@@ -1,6 +1,31 @@
 import { createFileRoute } from '@tanstack/react-router';
 import BlogPage from '@/fsd/views/blog/ui/BlogPage';
 
+interface BlogSearchParams {
+	page?: number;
+	pageSize?: number;
+	sortField?: string;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+	category?: string;
+}
+
 export const Route = createFileRoute('/blog/')({
 	component: BlogPage,
+	validateSearch: (search: Record<string, unknown>): BlogSearchParams => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			pageSize:
+				typeof search.pageSize === 'number' ? search.pageSize : undefined,
+			sortField:
+				typeof search.sortField === 'string' ? search.sortField : undefined,
+			sortOrder:
+				search.sortOrder === 'asc' || search.sortOrder === 'desc'
+					? search.sortOrder
+					: undefined,
+			filter: typeof search.filter === 'string' ? search.filter : undefined,
+			category:
+				typeof search.category === 'string' ? search.category : undefined,
+		};
+	},
 });

--- a/apps/admin/src/routes/gallery/photos/index.tsx
+++ b/apps/admin/src/routes/gallery/photos/index.tsx
@@ -1,6 +1,28 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { GalleryPage } from '@/fsd/views/gallery';
 
+interface PhotoSearchParams {
+	page?: number;
+	pageSize?: number;
+	sortField?: string;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+}
+
 export const Route = createFileRoute('/gallery/photos/')({
 	component: () => <GalleryPage />,
+	validateSearch: (search: Record<string, unknown>): PhotoSearchParams => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			pageSize:
+				typeof search.pageSize === 'number' ? search.pageSize : undefined,
+			sortField:
+				typeof search.sortField === 'string' ? search.sortField : undefined,
+			sortOrder:
+				search.sortOrder === 'asc' || search.sortOrder === 'desc'
+					? search.sortOrder
+					: undefined,
+			filter: typeof search.filter === 'string' ? search.filter : undefined,
+		};
+	},
 });

--- a/apps/admin/src/routes/places/index.tsx
+++ b/apps/admin/src/routes/places/index.tsx
@@ -1,6 +1,31 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { PlacePage } from '@/fsd/views/places/ui/PlacePage';
 
+interface PlaceSearchParams {
+	page?: number;
+	pageSize?: number;
+	sortField?: string;
+	sortOrder?: 'asc' | 'desc';
+	filter?: string;
+	category?: string;
+}
+
 export const Route = createFileRoute('/places/')({
 	component: PlacePage,
+	validateSearch: (search: Record<string, unknown>): PlaceSearchParams => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			pageSize:
+				typeof search.pageSize === 'number' ? search.pageSize : undefined,
+			sortField:
+				typeof search.sortField === 'string' ? search.sortField : undefined,
+			sortOrder:
+				search.sortOrder === 'asc' || search.sortOrder === 'desc'
+					? search.sortOrder
+					: undefined,
+			filter: typeof search.filter === 'string' ? search.filter : undefined,
+			category:
+				typeof search.category === 'string' ? search.category : undefined,
+		};
+	},
 });

--- a/apps/admin/src/routes/subscribers/index.tsx
+++ b/apps/admin/src/routes/subscribers/index.tsx
@@ -1,6 +1,23 @@
 import { createFileRoute } from '@tanstack/react-router';
 import SubscribersPage from '@/fsd/views/subscribers/ui/SubscribersPage';
 
+interface SubscriberSearchParams {
+	page?: number;
+	filter?: string;
+	category?: string;
+	isActive?: boolean;
+}
+
 export const Route = createFileRoute('/subscribers/')({
 	component: SubscribersPage,
+	validateSearch: (search: Record<string, unknown>): SubscriberSearchParams => {
+		return {
+			page: typeof search.page === 'number' ? search.page : undefined,
+			filter: typeof search.filter === 'string' ? search.filter : undefined,
+			category:
+				typeof search.category === 'string' ? search.category : undefined,
+			isActive:
+				typeof search.isActive === 'boolean' ? search.isActive : undefined,
+		};
+	},
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -76,6 +76,7 @@
     "@jung/typescript-config": "workspace:*",
     "@next/bundle-analyzer": "^15.2.1",
     "@shikijs/types": "^3.3.0",
+    "@supabase/auth-js": "^2.65.0",
     "@types/hast": "^3.0.4",
     "@types/negotiator": "^0.6.3",
     "@types/node": "^20.14.1",

--- a/packages/api/__tests__/analytics.test.ts
+++ b/packages/api/__tests__/analytics.test.ts
@@ -11,7 +11,7 @@ vi.mock('../lib/supabase', () => ({
 }));
 
 const createCaller = createCallerFactory(analyticsRouter);
-const caller = createCaller({});
+const caller = createCaller({ user: null });
 
 describe('analyticsRouter', () => {
 	beforeEach(() => {

--- a/packages/api/lib/trpc.ts
+++ b/packages/api/lib/trpc.ts
@@ -3,7 +3,18 @@ import { initTRPC, TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import { ZodError } from 'zod';
 
-export const createTRPCContext = async (opts?: { headers?: Headers }) => {
+export interface TRPCUser {
+	id: string;
+	email?: string;
+	app_metadata: Record<string, unknown>;
+	user_metadata: Record<string, unknown>;
+	aud: string;
+	created_at: string;
+}
+
+export const createTRPCContext = async (opts?: {
+	headers?: Headers;
+}): Promise<{ user: TRPCUser | null }> => {
 	const authHeader = opts?.headers?.get('authorization');
 
 	if (!authHeader?.startsWith('Bearer ')) {
@@ -28,7 +39,7 @@ export const createTRPCContext = async (opts?: { headers?: Headers }) => {
 		const {
 			data: { user },
 		} = await supabase.auth.getUser(token);
-		return { user };
+		return { user: user as TRPCUser | null };
 	} catch {
 		return { user: null };
 	}

--- a/packages/api/services/newsletter.ts
+++ b/packages/api/services/newsletter.ts
@@ -32,7 +32,7 @@ interface SendNewsletterInput {
 	testEmail?: string;
 }
 
-interface SendNewsletterResult {
+export interface SendNewsletterResult {
 	sentCount: number;
 	failedCount: number;
 	subscriberCount: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       jest:
         specifier: ^30.1.1
         version: 30.2.0(@types/node@20.19.24)
+      jsdom:
+        specifier: ^20.0.3
+        version: 20.0.3
       lefthook:
         specifier: ^2.0.13
         version: 2.0.13
@@ -66,7 +69,7 @@ importers:
         version: 2.7.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(tsx@4.21.0)
+        version: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(jsdom@20.0.3)(tsx@4.21.0)
 
   apps/admin:
     dependencies:
@@ -454,6 +457,9 @@ importers:
       '@shikijs/types':
         specifier: ^3.3.0
         version: 3.14.0
+      '@supabase/auth-js':
+        specifier: ^2.65.0
+        version: 2.93.3
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -7313,7 +7319,7 @@ packages:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(tsx@4.21.0)
+      vitest: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(jsdom@20.0.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7422,7 +7428,7 @@ packages:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(tsx@4.21.0)
+      vitest: 4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(jsdom@20.0.3)(tsx@4.21.0)
     dev: true
 
   /@vitest/utils@3.2.4:
@@ -15060,7 +15066,7 @@ packages:
       vite: 7.3.0(@types/node@20.19.24)(tsx@4.21.0)
     dev: false
 
-  /vitest@4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(tsx@4.21.0):
+  /vitest@4.0.16(@types/node@20.19.24)(@vitest/ui@4.0.16)(jsdom@20.0.3)(tsx@4.21.0):
     resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -15105,6 +15111,7 @@ packages:
       '@vitest/utils': 4.0.16
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
+      jsdom: 20.0.3
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Add `validateSearch` to admin routes (articles, blog, photos, places, subscribers) fixing `never` typed search params
- Fix trailing slash mismatch in `useNavigate` from paths (`/articles` → `/articles/`)
- Export `SendNewsletterResult` type from newsletter service
- Define `TRPCUser` interface to decouple `@supabase/auth-js` internal types from consumer packages
- Fix analytics test context type mismatch
- Remove unused `isSelected`/`onToggle` props from `TableContent`
- Fix `SubscriberStats` nested property access (`categoryDistribution`)

## Test plan
- [x] `pnpm typecheck` passes (web + admin + api all green)
- [x] `pnpm biome check .` passes (0 errors)
- [ ] Verify admin routes work with search params (articles, blog, subscribers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)