### PR TITLE
fix(admin): regenerate routeTree with correct trailing slash types

### DIFF
--- a/apps/admin/src/routeTree.gen.ts
+++ b/apps/admin/src/routeTree.gen.ts
@@ -141,26 +141,26 @@ const GalleryPhotosPhotoIdEditRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/articles': typeof ArticlesIndexRoute
-  '/blog': typeof BlogIndexRoute
-  '/community': typeof CommunityIndexRoute
-  '/guestbook': typeof GuestbookIndexRoute
-  '/login': typeof LoginIndexRoute
-  '/places': typeof PlacesIndexRoute
-  '/subscribers': typeof SubscribersIndexRoute
+  '/articles/': typeof ArticlesIndexRoute
+  '/blog/': typeof BlogIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/guestbook/': typeof GuestbookIndexRoute
+  '/login/': typeof LoginIndexRoute
+  '/places/': typeof PlacesIndexRoute
+  '/subscribers/': typeof SubscribersIndexRoute
   '/articles/edit/$articleId': typeof ArticlesEditArticleIdRoute
   '/blog/edit/$postId': typeof BlogEditPostIdRoute
   '/gallery/collections/$collectionId': typeof GalleryCollectionsCollectionIdRoute
   '/places/$placeId/edit': typeof PlacesPlaceIdEditRoute
-  '/articles/new': typeof ArticlesNewIndexRoute
-  '/blog/categories': typeof BlogCategoriesIndexRoute
-  '/blog/new': typeof BlogNewIndexRoute
-  '/gallery/collections': typeof GalleryCollectionsIndexRoute
-  '/gallery/photos': typeof GalleryPhotosIndexRoute
-  '/places/categories': typeof PlacesCategoriesIndexRoute
-  '/places/new': typeof PlacesNewIndexRoute
+  '/articles/new/': typeof ArticlesNewIndexRoute
+  '/blog/categories/': typeof BlogCategoriesIndexRoute
+  '/blog/new/': typeof BlogNewIndexRoute
+  '/gallery/collections/': typeof GalleryCollectionsIndexRoute
+  '/gallery/photos/': typeof GalleryPhotosIndexRoute
+  '/places/categories/': typeof PlacesCategoriesIndexRoute
+  '/places/new/': typeof PlacesNewIndexRoute
   '/gallery/photos/$photoId/edit': typeof GalleryPhotosPhotoIdEditRoute
-  '/gallery/photos/new': typeof GalleryPhotosNewIndexRoute
+  '/gallery/photos/new/': typeof GalleryPhotosNewIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -213,26 +213,26 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/articles'
-    | '/blog'
-    | '/community'
-    | '/guestbook'
-    | '/login'
-    | '/places'
-    | '/subscribers'
+    | '/articles/'
+    | '/blog/'
+    | '/community/'
+    | '/guestbook/'
+    | '/login/'
+    | '/places/'
+    | '/subscribers/'
     | '/articles/edit/$articleId'
     | '/blog/edit/$postId'
     | '/gallery/collections/$collectionId'
     | '/places/$placeId/edit'
-    | '/articles/new'
-    | '/blog/categories'
-    | '/blog/new'
-    | '/gallery/collections'
-    | '/gallery/photos'
-    | '/places/categories'
-    | '/places/new'
+    | '/articles/new/'
+    | '/blog/categories/'
+    | '/blog/new/'
+    | '/gallery/collections/'
+    | '/gallery/photos/'
+    | '/places/categories/'
+    | '/places/new/'
     | '/gallery/photos/$photoId/edit'
-    | '/gallery/photos/new'
+    | '/gallery/photos/new/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -317,98 +317,98 @@ declare module '@tanstack/react-router' {
     '/subscribers/': {
       id: '/subscribers/'
       path: '/subscribers'
-      fullPath: '/subscribers'
+      fullPath: '/subscribers/'
       preLoaderRoute: typeof SubscribersIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/places/': {
       id: '/places/'
       path: '/places'
-      fullPath: '/places'
+      fullPath: '/places/'
       preLoaderRoute: typeof PlacesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login/': {
       id: '/login/'
       path: '/login'
-      fullPath: '/login'
+      fullPath: '/login/'
       preLoaderRoute: typeof LoginIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/guestbook/': {
       id: '/guestbook/'
       path: '/guestbook'
-      fullPath: '/guestbook'
+      fullPath: '/guestbook/'
       preLoaderRoute: typeof GuestbookIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/community/': {
       id: '/community/'
       path: '/community'
-      fullPath: '/community'
+      fullPath: '/community/'
       preLoaderRoute: typeof CommunityIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/': {
       id: '/blog/'
       path: '/blog'
-      fullPath: '/blog'
+      fullPath: '/blog/'
       preLoaderRoute: typeof BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/articles/': {
       id: '/articles/'
       path: '/articles'
-      fullPath: '/articles'
+      fullPath: '/articles/'
       preLoaderRoute: typeof ArticlesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/places/new/': {
       id: '/places/new/'
       path: '/places/new'
-      fullPath: '/places/new'
+      fullPath: '/places/new/'
       preLoaderRoute: typeof PlacesNewIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/places/categories/': {
       id: '/places/categories/'
       path: '/places/categories'
-      fullPath: '/places/categories'
+      fullPath: '/places/categories/'
       preLoaderRoute: typeof PlacesCategoriesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/gallery/photos/': {
       id: '/gallery/photos/'
       path: '/gallery/photos'
-      fullPath: '/gallery/photos'
+      fullPath: '/gallery/photos/'
       preLoaderRoute: typeof GalleryPhotosIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/gallery/collections/': {
       id: '/gallery/collections/'
       path: '/gallery/collections'
-      fullPath: '/gallery/collections'
+      fullPath: '/gallery/collections/'
       preLoaderRoute: typeof GalleryCollectionsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/new/': {
       id: '/blog/new/'
       path: '/blog/new'
-      fullPath: '/blog/new'
+      fullPath: '/blog/new/'
       preLoaderRoute: typeof BlogNewIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/categories/': {
       id: '/blog/categories/'
       path: '/blog/categories'
-      fullPath: '/blog/categories'
+      fullPath: '/blog/categories/'
       preLoaderRoute: typeof BlogCategoriesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/articles/new/': {
       id: '/articles/new/'
       path: '/articles/new'
-      fullPath: '/articles/new'
+      fullPath: '/articles/new/'
       preLoaderRoute: typeof ArticlesNewIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -443,7 +443,7 @@ declare module '@tanstack/react-router' {
     '/gallery/photos/new/': {
       id: '/gallery/photos/new/'
       path: '/gallery/photos/new'
-      fullPath: '/gallery/photos/new'
+      fullPath: '/gallery/photos/new/'
       preLoaderRoute: typeof GalleryPhotosNewIndexRouteImport
       parentRoute: typeof rootRouteImport
     }


### PR DESCRIPTION
## Summary
- Admin app의 `routeTree.gen.ts`가 stale 상태로 커밋되어 `FileRoutesByFullPath`/`FileRoutesByTo` 타입에서 trailing slash가 누락
- 이로 인해 `useSearch`/`useNavigate`의 `from` 파라미터가 search params 타입을 resolve하지 못해 59개 TypeScript 에러 발생
- `@tanstack/router-cli generate`로 재생성하여 모든 타입 에러 해결

## Test plan
- [x] `pnpm turbo run typecheck` 통과 확인 (59개 에러 → 0개)
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)